### PR TITLE
fix: Normalize Docstrings

### DIFF
--- a/src/copick_utils/cli/clipmesh.py
+++ b/src/copick_utils/cli/clipmesh.py
@@ -20,7 +20,7 @@ from copick_utils.util.config_models import create_reference_config
 
 @click.command(
     context_settings={"show_default": True},
-    short_help="Limit meshes to vertices within distance of a reference surface.",
+    short_help="Limit mesh vertices within distance of a reference surface.",
     no_args_is_help=True,
 )
 @add_config_option
@@ -66,29 +66,44 @@ def clipmesh(
     debug,
 ):
     """
-    Limit meshes to vertices within a certain distance of a reference surface.
+    Limit mesh vertices within distance of a reference surface.
 
-    \b
+    For each input mesh, vertices are kept or dropped based on their distance to a
+    reference surface. The reference can be another mesh, a segmentation, or a tomogram
+    boundary, and exactly one reference must be provided. By default, vertices within
+    --max-distance of the reference are kept; pass --invert to keep only the vertices
+    that lie beyond that distance instead.
+
     URI Format:
+
+        \b
         Meshes: object_name:user_id/session_id
         Segmentations: name:user_id/session_id@voxel_spacing
         Tomograms: tomo_type@voxel_spacing
 
-    \b
-    The reference surface can be a mesh, segmentation, or tomogram boundary.
-    By default, vertices within the specified distance will be kept.
-    Use --invert to keep vertices beyond the specified distance instead.
-
-    \b
     Examples:
-        # Keep vertices within 50Å of mesh reference
-        copick logical clipmesh -i "membrane:user1/full-001" -rm "boundary:user1/boundary-001" -o "membrane:clipmesh/near-001" --max-distance 50.0
 
-        # Remove vertices within 50Å of tomogram boundary (keep interior vertices)
-        copick logical clipmesh -i "membrane:user1/full-001" -rt "wbp@10.0" -o "membrane:clipmesh/interior-001" --max-distance 50.0 --invert
+        \b
+        # Keep vertices within 50Å of a mesh reference
+        copick logical clipmesh -i "membrane:user1/full-001" -rm "boundary:user1/boundary-001" \\
+            -o "membrane:clipmesh/near-001" --max-distance 50.0
 
-        # Keep vertices beyond 100Å from segmentation reference
-        copick logical clipmesh -i "membrane:user1/full-001" -rs "mask:user1/mask-001@10.0" -o "membrane:clipmesh/far-001" --max-distance 100.0 --invert
+        \b
+        # Remove vertices within 50Å of the tomogram boundary (keep interior vertices)
+        copick logical clipmesh -i "membrane:user1/full-001" -rt "wbp@10.0" \\
+            -o "membrane:clipmesh/interior-001" --max-distance 50.0 --invert
+
+        \b
+        # Keep vertices beyond 100Å from a segmentation reference
+        copick logical clipmesh -i "membrane:user1/full-001" -rs "mask:user1/mask-001@10.0" \\
+            -o "membrane:clipmesh/far-001" --max-distance 100.0 --invert
+
+    See Also:
+
+        \b
+        copick logical clippicks: limit picks by distance to a reference surface (the points analog)
+        copick logical clipseg: limit segmentation voxels by distance to a reference
+        copick logical meshop: build or combine the meshes you clip
     """
     from copick_utils.logical.distance_operations import limit_mesh_by_distance_lazy_batch
 

--- a/src/copick_utils/cli/clippicks.py
+++ b/src/copick_utils/cli/clippicks.py
@@ -60,30 +60,46 @@ def clippicks(
     debug,
 ):
     """
-    Limit picks to those within a certain distance of a reference surface.
+    Limit picks to those within distance of a reference surface.
 
-    \b
+    The reference surface can be a mesh, segmentation, or tomogram boundary. Each input
+    pick is kept or dropped based on its distance to the nearest point on that surface.
+    By default, picks within the specified `--max-distance` are kept; use `--invert` to
+    keep only the picks that lie beyond that distance instead.
+
+    Exactly one reference must be supplied via `--ref-mesh`, `--ref-seg`, or
+    `--ref-tomogram`. Distances are measured in angstroms.
+
     URI Format:
+
+        \b
         Picks: object_name:user_id/session_id
         Meshes: object_name:user_id/session_id
         Segmentations: name:user_id/session_id@voxel_spacing
         Tomograms: tomo_type@voxel_spacing
 
-    \b
-    The reference surface can be a mesh, segmentation, or tomogram boundary.
-    By default, picks within the specified distance will be kept.
-    Use --invert to keep picks beyond the specified distance instead.
-
-    \b
     Examples:
-        # Keep picks within 50Å of mesh reference
-        copick logical clippicks -i "ribosome:user1/all-001" -rm "boundary:user1/boundary-001" -o "ribosome:clippicks/near-001" --max-distance 50.0
 
-        # Remove picks within 50Å of tomogram boundary (keep interior picks)
-        copick logical clippicks -i "ribosome:user1/all-001" -rt "wbp@10.0" -o "ribosome:clippicks/interior-001" --max-distance 50.0 --invert
+        \b
+        # Keep picks within 50A of a mesh reference
+        copick logical clippicks -i "ribosome:user1/all-001" -rm "boundary:user1/boundary-001" \\
+            -o "ribosome:clippicks/near-001" --max-distance 50.0
 
-        # Keep picks beyond 100Å from segmentation reference
-        copick logical clippicks -i "ribosome:user1/all-001" -rs "mask:user1/mask-001@10.0" -o "ribosome:clippicks/far-001" --max-distance 100.0 --invert
+        \b
+        # Remove picks within 50A of a tomogram boundary (keep interior picks)
+        copick logical clippicks -i "ribosome:user1/all-001" -rt "wbp@10.0" \\
+            -o "ribosome:clippicks/interior-001" --max-distance 50.0 --invert
+
+        \b
+        # Keep picks beyond 100A from a segmentation reference
+        copick logical clippicks -i "ribosome:user1/all-001" -rs "mask:user1/mask-001@10.0" \\
+            -o "ribosome:clippicks/far-001" --max-distance 100.0 --invert
+
+    See Also:
+
+        \b
+        copick convert mesh2caps: extract slab caps so clipping ignores the side walls
+        copick logical meshop: build the reference mesh used as the clipping surface
     """
     from copick_utils.logical.distance_operations import limit_picks_by_distance_lazy_batch
 

--- a/src/copick_utils/cli/clipseg.py
+++ b/src/copick_utils/cli/clipseg.py
@@ -20,7 +20,7 @@ from copick_utils.util.config_models import create_reference_config
 
 @click.command(
     context_settings={"show_default": True},
-    short_help="Limit segmentations to voxels within distance of a reference surface.",
+    short_help="Limit segmentation voxels by distance to a reference.",
     no_args_is_help=True,
 )
 @add_config_option
@@ -58,29 +58,47 @@ def clipseg(
     debug,
 ):
     """
-    Limit segmentations to voxels within a certain distance of a reference surface.
+    Limit segmentation voxels by distance to a reference.
 
-    \b
+    The reference surface can be a mesh, a segmentation, or a tomogram boundary. Each
+    input segmentation voxel is kept or dropped based on its distance to that surface.
+    By default, voxels within `--max-distance` (in angstroms) of the surface are kept;
+    pass `--invert` to instead keep only the voxels beyond that distance.
+
+    Provide exactly one reference via `--ref-mesh`, `--ref-seg`, or `--ref-tomogram`.
+
     URI Format:
+
+        \b
         Segmentations: name:user_id/session_id@voxel_spacing
         Meshes: object_name:user_id/session_id
         Tomograms: tomo_type@voxel_spacing
 
-    \b
-    The reference surface can be a mesh, segmentation, or tomogram boundary.
-    By default, voxels within the specified distance will be kept.
-    Use --invert to keep voxels beyond the specified distance instead.
-
-    \b
     Examples:
-        # Keep voxels within 50Å of mesh reference
-        copick logical clipseg -i "membrane:user1/full-001@10.0" -rm "boundary:user1/boundary-001" -o "membrane:clipseg/near-001@10.0" --max-distance 50.0
 
-        # Remove voxels within 50Å of tomogram boundary (keep interior voxels)
-        copick logical clipseg -i "membrane:user1/full-001@10.0" -rt "wbp@10.0" -o "membrane:clipseg/interior-001@10.0" --max-distance 50.0 --invert
+        \b
+        # Keep voxels within 50Å of a mesh reference
+        copick logical clipseg -i "membrane:user1/full-001@10.0" \\
+            -rm "boundary:user1/boundary-001" \\
+            -o "membrane:clipseg/near-001@10.0" --max-distance 50.0
 
-        # Keep voxels beyond 100Å from segmentation reference
-        copick logical clipseg -i "membrane:user1/full-001@10.0" -rs "mask:user1/mask-001@10.0" -o "membrane:clipseg/far-001@10.0" --max-distance 100.0 --invert
+        \b
+        # Remove voxels within 50Å of the tomogram boundary (keep the interior)
+        copick logical clipseg -i "membrane:user1/full-001@10.0" \\
+            -rt "wbp@10.0" \\
+            -o "membrane:clipseg/interior-001@10.0" --max-distance 50.0 --invert
+
+        \b
+        # Keep voxels beyond 100Å from a segmentation reference
+        copick logical clipseg -i "membrane:user1/full-001@10.0" \\
+            -rs "mask:user1/mask-001@10.0" \\
+            -o "membrane:clipseg/far-001@10.0" --max-distance 100.0 --invert
+
+    See Also:
+
+        \b
+        copick logical clippicks: limit picks (not voxels) by distance to a reference
+        copick convert mesh2caps: extract a side-wall-free cap mesh to use as a reference
     """
     from copick_utils.logical.distance_operations import limit_segmentation_by_distance_lazy_batch
 

--- a/src/copick_utils/cli/combine_labels.py
+++ b/src/copick_utils/cli/combine_labels.py
@@ -38,33 +38,41 @@ def combine(
     debug,
 ):
     """
-    Combine single-label segmentations into one multilabel segmentation.
+    Combine single-label segmentations into a multilabel segmentation.
 
-    This is the inverse of `copick process split`. Takes multiple binary/single-label
-    segmentations (matched by a pattern) and merges them into a single multilabel
-    volume. Each input segmentation's name is looked up in the copick config to
-    determine its integer label value.
+    This is the inverse of `copick process split`. It takes multiple binary/single-label
+    segmentations (matched by a pattern) and merges them into a single multilabel volume.
+    Each input segmentation's name is looked up in the copick config to determine its
+    integer label value.
 
-    \b
-    Overlap Resolution:
-        When multiple inputs overlap, the lowest label value wins. This is
-        deterministic and reproducible. Overlaps are logged as warnings.
+    When multiple inputs overlap, the lowest label value wins. This resolution is
+    deterministic and reproducible, and overlapping voxels are logged as warnings.
 
-    \b
     URI Format:
+
+        \b
         Segmentations: name:user_id/session_id@voxel_spacing
         Use glob/regex patterns to match multiple segmentations per run.
 
-    \b
     Examples:
+
+        \b
         # Combine all segmentations from a split operation
         copick process combine -i "*:split/*@20" -o "multilabel:combine/0"
 
-        # Combine specific user's segmentations using regex
+        \b
+        # Combine a specific user's segmentations using regex
         copick process combine -i "re:.*:napari/manual@20" -o "combined:combine/0"
 
+        \b
         # Combine for specific runs
         copick process combine -r run1 -r run2 -i "*:user1/session@10.0" -o "labels:combine/0"
+
+    See Also:
+
+        \b
+        copick process split: the inverse operation (split a multilabel segmentation into single labels)
+        copick process expand-labels: grow labels to fill holes and gaps in a segmentation
     """
     from copick_utils.process.combine_labels import combine_labels_lazy_batch
 

--- a/src/copick_utils/cli/download.py
+++ b/src/copick_utils/cli/download.py
@@ -23,7 +23,27 @@ import click
 )
 def project(dataset: str, output: str):
     """
-    Download tilt series and alignments from the CryoET Data Portal for sub-tomogram averaging with py2rely.
+    Download tilt series and alignments from the CryoET Data Portal.
+
+    Fetches the AreTomo files (the raw tilt series plus their alignment files) for every
+    run in a CryoET Data Portal dataset and writes them to a local directory, laid out for
+    sub-tomogram averaging with py2rely. Pass the numeric portal dataset ID via `--dataset`;
+    all matching tilt series are downloaded in parallel into `--output`.
+
+    Examples:
+
+        \b
+        # Download a dataset's tilt series and alignments into the current directory
+        copick download project -ds 10000 -o .
+
+        \b
+        # Download into a dedicated output directory
+        copick download project --dataset 10445 --output ./aretomo_inputs
+
+    See Also:
+
+        \b
+        copick config dataportal: build a copick config from CryoET Data Portal datasets
     """
     download_project(dataset, output)
 

--- a/src/copick_utils/cli/enclosed.py
+++ b/src/copick_utils/cli/enclosed.py
@@ -82,27 +82,45 @@ def enclosed(
 
     This command identifies connected components in the first segmentation (inner) that are
     completely surrounded by the second segmentation (outer), and removes them from the inner
-    segmentation. Useful for cleaning up noise, artifacts, or unwanted fragments.
+    segmentation. Useful for cleaning up noise, artifacts, or unwanted fragments that are trapped
+    inside a larger structure.
 
-    \b
-    URI Format:
-        Segmentations: name:user_id/session_id (voxel spacing specified via --voxel-spacing)
+    Components are filtered geometrically: each is dilated by `--margin` voxels and kept only if it
+    is fully contained within the outer segmentation. Optional `--min-size`/`--max-size` bounds (in
+    cubic angstroms) restrict which components are considered for removal.
 
-    \b
     Algorithm:
+
+        \b
         1. Label connected components in the inner segmentation (input1)
         2. Dilate each component by the specified margin
         3. Check if the dilated component is fully contained within the outer segmentation (input2)
         4. If enclosed (and within size limits), remove the component from the inner segmentation
         5. Output cleaned version of the inner segmentation
 
-    \b
-    Examples:
-        # Remove small vesicle fragments that are enclosed by membrane
-        copick logical enclosed -vs 10.0 -i1 "vesicle:user1/auto-001" -i2 "membrane:user1/manual-001" -o "vesicle_clean"
+    URI Format:
 
+        \b
+        Segmentations: name:user_id/session_id (voxel spacing specified via --voxel-spacing)
+
+    Examples:
+
+        \b
+        # Remove small vesicle fragments that are enclosed by membrane
+        copick logical enclosed -vs 10.0 -i1 "vesicle:user1/auto-001" -i2 "membrane:user1/manual-001" \\
+            -o "vesicle-clean:enclosed/0"
+
+        \b
         # Remove noise fragments with size filtering (volumes in Å³)
-        copick logical enclosed -vs 10.0 -i1 "fragments:user1/.*" -i2 "cell:user1/.*" -o "cleaned" --min-size 1000 --max-size 100000 --margin 2
+        copick logical enclosed -vs 10.0 -i1 "fragments:user1/.*" -i2 "cell:user1/.*" \\
+            -o "cleaned:enclosed/0" --min-size 1000 --max-size 100000 --margin 2
+
+    See Also:
+
+        \b
+        copick logical segop: combine two segmentations with boolean operations
+        copick logical clipseg: limit segmentation voxels by distance to a reference
+        copick process filter-components: remove connected components by size instead of enclosure
     """
 
     logger = get_logger(__name__, debug=debug)

--- a/src/copick_utils/cli/expand_labels.py
+++ b/src/copick_utils/cli/expand_labels.py
@@ -80,29 +80,44 @@ def expand_labels(
     When --max-hole-size is specified, expansion is restricted to only fill background
     holes smaller than the given volume. This prevents labels from expanding beyond
     their natural borders (e.g., filling internal holes in a cell without expanding
-    outward into the surrounding background). Use "seg-stats --include-background"
+    outward into the surrounding background). Use `seg-stats --include-background`
     to determine appropriate hole size values.
 
-    \b
     URI Format:
+
+        \b
         Segmentations: name:user_id/session_id@voxel_spacing
 
-    \b
     Examples:
+
+        \b
         # Expand labels by 20 angstroms
         copick process expand-labels -i "membrane:user1/auto-001@10.0" -o "membrane_filled" --distance 20.0
 
+        \b
         # Fill only holes smaller than 500000 cubic angstroms
-        copick process expand-labels -i "membrane:user1/auto-001@10.0" -o "filled" --distance 20.0 --max-hole-size 500000
+        copick process expand-labels -i "membrane:user1/auto-001@10.0" -o "filled" \\
+            --distance 20.0 --max-hole-size 500000
 
+        \b
         # Fill holes using voxel units
-        copick process expand-labels -i "membrane:user1/auto-001@10.0" -o "filled" --distance 20.0 --max-hole-size 500 --size-unit voxel
+        copick process expand-labels -i "membrane:user1/auto-001@10.0" -o "filled" \\
+            --distance 20.0 --max-hole-size 500 --size-unit voxel
 
+        \b
         # Expand labels across specific runs
-        copick process expand-labels -i "organelle:user1/pred@10.0" -o "organelle_expanded" --distance 15.0 -r run1 -r run2
+        copick process expand-labels -i "organelle:user1/pred@10.0" -o "organelle_expanded" \\
+            --distance 15.0 -r run1 -r run2
 
+        \b
         # Expand with custom output URI
         copick process expand-labels -i "membrane:user1/manual@10.0" -o "membrane:expand-labels/0@10.0" --distance 30.0
+
+    See Also:
+
+        \b
+        copick process seg-stats: report connected-component sizes to choose --max-hole-size
+        copick process filter-components: remove small connected components by size
     """
     from copick_utils.process.expand_labels import expand_labels_lazy_batch
 

--- a/src/copick_utils/cli/filter_components.py
+++ b/src/copick_utils/cli/filter_components.py
@@ -78,24 +78,46 @@ def filter_components(
     """
     Filter connected components in segmentations by size.
 
-    This command identifies connected components in a segmentation and removes those
-    that fall outside the specified size range. Sizes can be specified in cubic
-    angstroms (default) or cubic voxels using --size-unit.
+    This command identifies connected components in a segmentation and removes those that
+    fall outside the specified size range. Sizes can be given in cubic angstroms (default)
+    or cubic voxels via --size-unit, and component adjacency is controlled by --connectivity
+    (face = 6-connected, face-edge = 18-connected, all = 26-connected).
 
-    \b
+    Pass --keep-largest N to retain only the N largest components by voxel count, applied on
+    top of any --min-size/--max-size limits. Run `copick process seg-stats` first to inspect
+    component sizes and choose sensible thresholds.
+
     URI Format:
+
+        \b
         Segmentations: name:user_id/session_id@voxel_spacing
 
-    \b
     Examples:
+
+        \b
         # Remove small noise components (keep only larger than 50000 Å³)
         copick process filter-components -i "membrane:user1/auto-001@10.0" -o "membrane_clean" --min-size 50000
 
+        \b
         # Filter by cubic voxels instead of angstroms
-        copick process filter-components -i "membrane:user1/auto-001@10.0" -o "membrane_clean" --min-size 50 --size-unit voxel
+        copick process filter-components -i "membrane:user1/auto-001@10.0" -o "membrane_clean" \\
+            --min-size 50 --size-unit voxel
 
+        \b
         # Keep only medium-sized components (between 10000 and 1000000 Å³)
-        copick process filter-components -i "particles:user1/.*@10.0" -o "particles_filtered" --min-size 10000 --max-size 1000000
+        copick process filter-components -i "particles:user1/.*@10.0" -o "particles_filtered" \\
+            --min-size 10000 --max-size 1000000
+
+        \b
+        # Keep only the single largest connected component
+        copick process filter-components -i "membrane:user1/auto-001@10.0" -o "membrane_main" --keep-largest 1
+
+    See Also:
+
+        \b
+        copick process seg-stats: report connected-component size statistics to choose thresholds
+        copick process separate-components: relabel each connected component as a distinct class
+        copick logical enclosed: remove components fully enclosed by another segmentation
     """
     from copick_utils.process.filter_components import filter_components_lazy_batch
 

--- a/src/copick_utils/cli/fit_spline.py
+++ b/src/copick_utils/cli/fit_spline.py
@@ -11,7 +11,7 @@ from copick_utils.util.config_models import create_simple_config
 
 @click.command(
     context_settings={"show_default": True},
-    short_help="Fit 3D splines to skeletons and generate picks with orientations.",
+    short_help="Fit 3D splines to skeletons and generate oriented picks.",
     no_args_is_help=True,
 )
 @add_config_option
@@ -96,25 +96,39 @@ def fit_spline(
     output_uri,
     debug,
 ):
-    """Fit 3D splines to skeletonized segmentations and generate picks with orientations.
+    """Fit 3D splines to skeletons and generate oriented picks.
 
-    \b
+    Fits regularized 3D parametric splines to skeletonized segmentation volumes and samples
+    points along each spline at a regular interval, producing picks. Orientations are computed
+    from the local spline direction when `--compute-transforms` is enabled.
+
+    Curvature-based outlier removal is applied iteratively to discard skeleton points that
+    produce unrealistically sharp bends, while the connectivity radius controls how skeleton
+    voxels are joined into a connected curve before fitting.
+
     URI Format:
+
+        \b
         Segmentations: name:user_id/session_id@voxel_spacing
         Picks: object_name:user_id/session_id
 
-    \b
-    This command fits regularized 3D parametric splines to skeleton volumes and samples
-    points along the spline at regular intervals. Orientations are computed based on
-    the spline direction.
-
-    \b
     Examples:
-        # Fit splines to skeletonized components
-        copick process fit_spline -i "skeleton:skel/inst-.*@10.0" -o "skeleton:spline/spline-{input_session_id}" --spacing-distance 4.4 --voxel-spacing 10.0
 
-        # Process specific skeleton
-        copick process fit_spline -i "skeleton:skel/skel-0@10.0" -o "skeleton:spline/spline-0" --spacing-distance 2.0 --voxel-spacing 10.0
+        \b
+        # Fit splines to skeletonized components
+        copick process fit_spline -i "skeleton:skel/inst-.*@10.0" \\
+            -o "skeleton:spline/spline-{input_session_id}" --spacing-distance 4.4 --voxel-spacing 10.0
+
+        \b
+        # Process a single skeleton component
+        copick process fit_spline -i "skeleton:skel/skel-0@10.0" \\
+            -o "skeleton:spline/spline-0" --spacing-distance 2.0 --voxel-spacing 10.0
+
+    See Also:
+
+        \b
+        copick process skeletonize: produce the skeleton segmentations fed to this command
+        copick process separate_components: split a segmentation into per-instance skeletons first
     """
     from copick_utils.process.spline_fitting import fit_spline_lazy_batch
 

--- a/src/copick_utils/cli/hull.py
+++ b/src/copick_utils/cli/hull.py
@@ -59,21 +59,38 @@ def hull(
     """
     Compute hull operations on meshes.
 
-    \b
+    Currently supports convex hull computation, where the convex hull is the
+    smallest convex shape that contains all vertices of the original mesh. Each
+    input mesh is replaced by its hull; with `--individual-meshes` a separate
+    hull is written per instance using the `{instance_id}` placeholder in the
+    output URI.
+
     URI Format:
+
+        \b
         Meshes: object_name:user_id/session_id
 
-    \b
-    Currently supports convex hull computation, where the convex hull is the
-    smallest convex shape that contains all vertices of the original mesh.
-
-    \b
     Examples:
+
+        \b
         # Compute convex hull for meshes
         copick process hull -i "membrane:user1/session1" -o "membrane:hull/hull-session"
 
-        # Process specific runs
-        copick process hull -r run1 -r run2 -i "membrane:user1/session1" -o "membrane:hull/convex-001" --hull-type convex
+        \b
+        # Process specific runs with an explicit hull type
+        copick process hull -r run1 -r run2 --hull-type convex \\
+            -i "membrane:user1/session1" -o "membrane:hull/convex-001"
+
+        \b
+        # Emit one hull mesh per instance using the {instance_id} placeholder
+        copick process hull --individual-meshes \\
+            -i "membrane:user1/session1" -o "membrane:hull/inst-{instance_id}"
+
+    See Also:
+
+        \b
+        copick convert picks2mesh: build the meshes whose hulls you compute
+        copick logical meshop: combine hull meshes with boolean operations
     """
     from copick_utils.process.hull import hull_lazy_batch
 

--- a/src/copick_utils/cli/mesh2caps.py
+++ b/src/copick_utils/cli/mesh2caps.py
@@ -57,21 +57,31 @@ def mesh2caps(
     The resulting open mesh feeds ``copick logical clippicks`` to select particles within a distance
     of the top/bottom of the specimen WITHOUT the side walls contaminating the distance field.
 
-    \b
     URI Format:
+
+        \b
         Meshes: object_name:user_id/session_id
 
-    \b
     Examples:
+
+        \b
         # Extract both caps of the valid-sample slab
         copick convert mesh2caps -i "valid-sample:meshop/0" -o "valid-sample-caps:mesh2caps/0"
 
+        \b
         # Extract only the top cap, with a tighter cap angle
         copick convert mesh2caps --surface top --angle-threshold 30 \\
             -i "valid-sample:meshop/0" -o "valid-sample-caps:mesh2caps/top-0"
 
+        \b
         # Strongly tilted slab: infer the slab normal automatically
         copick convert mesh2caps --auto-axis -i "valid-sample:meshop/0" -o "valid-sample-caps:mesh2caps/0"
+
+    See Also:
+
+        \b
+        copick logical clippicks: select picks by distance to the extracted caps
+        copick logical meshop: build the slab box the caps are extracted from
     """
     from copick_utils.converters.caps_from_mesh import caps_from_mesh_lazy_batch
 

--- a/src/copick_utils/cli/mesh2picks.py
+++ b/src/copick_utils/cli/mesh2picks.py
@@ -13,7 +13,7 @@ from copick_utils.util.config_models import create_simple_config
 
 @click.command(
     context_settings={"show_default": True},
-    short_help="Convert mesh to picks.",
+    short_help="Convert meshes to picks using different sampling strategies.",
     no_args_is_help=True,
 )
 @add_config_option
@@ -90,19 +90,46 @@ def mesh2picks(
     """
     Convert meshes to picks using different sampling strategies.
 
-    \b
+    Samples points from copick meshes and writes them out as picks. Four sampling types
+    are supported: `inside` (points within the mesh volume), `surface` (points on the
+    mesh surface), `outside` (points outside the mesh), and `vertices` (the mesh vertices
+    themselves). For surface sampling you can attach the surface normals as orientations,
+    or request random orientations for any type.
+
+    A tomogram is required to define the volume bounds: it constrains `inside`/`outside`
+    sampling and the `--edge-dist` buffer (in voxels) that keeps points away from the
+    volume edges, and its voxel spacing sets the default `--min-dist` between points.
+
     URI Format:
+
+        \b
         Meshes: object_name:user_id/session_id
         Picks: object_name:user_id/session_id
         Tomograms: tomo_type@voxel_spacing
 
-    \b
     Examples:
-        # Convert single mesh to picks with surface sampling
-        copick convert mesh2picks -i "boundary:user1/boundary-001" --tomogram wbp@10.0 --sampling-type surface -o "boundary"
 
-        # Convert all boundary meshes using pattern matching
-        copick convert mesh2picks -i "boundary:user1/boundary-.*" -t wbp@10.0 --sampling-type inside -o "{input_session_id}"
+        \b
+        # Convert a single mesh to picks with surface sampling
+        copick convert mesh2picks -i "boundary:user1/boundary-001" --tomogram wbp@10.0 \\
+            --sampling-type surface -o "boundary"
+
+        \b
+        # Convert all boundary meshes using pattern matching, sampling inside the volume
+        copick convert mesh2picks -i "boundary:user1/boundary-.*" -t wbp@10.0 \\
+            --sampling-type inside -o "{input_session_id}"
+
+        \b
+        # Return the mesh vertices directly as picks
+        copick convert mesh2picks -i "boundary:user1/boundary-001" -t wbp@10.0 \\
+            --sampling-type vertices -o "boundary-vertices"
+
+    See Also:
+
+        \b
+        copick convert picks2mesh: the inverse — build a mesh from picks
+        copick convert mesh2caps: extract the top/bottom caps of a slab box mesh
+        copick convert mesh2seg: rasterize a mesh into a segmentation
     """
     from copick_utils.converters.picks_from_mesh import picks_from_mesh_lazy_batch
 

--- a/src/copick_utils/cli/mesh2seg.py
+++ b/src/copick_utils/cli/mesh2seg.py
@@ -16,7 +16,7 @@ from copick_utils.util.config_models import create_simple_config
 
 @click.command(
     context_settings={"show_default": True},
-    short_help="Convert mesh to segmentation.",
+    short_help="Convert meshes to segmentation volumes.",
     no_args_is_help=True,
 )
 @add_config_option
@@ -53,44 +53,49 @@ def mesh2seg(
     debug,
 ):
     """
-    Convert meshes to segmentation volumes with multiple voxelization modes.
+    Convert meshes to segmentation volumes.
 
-    \b
+    Voxelize one or more meshes into a label volume on a reference tomogram grid. Two
+    voxelization modes are supported: `watertight` fills the entire interior using ray
+    casting, while `boundary` voxelizes only the surface with a controllable sampling
+    density. Use `--invert` to fill outside the mesh instead of inside (watertight mode),
+    and `--boundary-sampling-density` to tune the surface sampling in boundary mode.
+
+    Input meshes are selected by pattern: exact (`membrane:user1/session1`), glob
+    (`membrane:user1/session*`), regex (`re:membrane:user\\d+/session\\d+`), or a bare
+    wildcard (`membrane`, which expands to `membrane:*/*`).
+
     URI Format:
+
+        \b
         Meshes: object_name:user_id/session_id
         Segmentations: name:user_id/session_id@voxel_spacing?multilabel=true
 
-    \b
-    Pattern Matching:
-        - Exact: "membrane:user1/session1"
-        - Glob: "membrane:user1/session*" or "membrane:*/manual-*"
-        - Regex: "re:membrane:user\\d+/session\\d+"
-        - Wildcard: "membrane" (expands to "membrane:*/*")
-
-    \b
-    Voxelization modes:
-        - watertight: Fill entire interior volume using ray casting
-        - boundary: Voxelize only the surface with controllable sampling density
-
-    \b
-    Additional options:
-        - --invert: Fill outside instead of inside (watertight mode)
-        - --boundary-sampling-density: Surface sampling density (boundary mode)
-
-    \b
     Examples:
+
+        \b
         # Convert mesh interior to segmentation (default)
         copick convert mesh2seg -i "membrane:user1/manual-001" -o "membrane:mesh2seg/from-mesh-001@10.0"
 
+        \b
         # Convert mesh boundary only with high sampling density
         copick convert mesh2seg --mode boundary --boundary-sampling-density 2.0 \\
             -i "membrane:user1/manual-001" -o "membrane:mesh2seg/boundary-001@10.0"
 
+        \b
         # Invert watertight mesh (fill outside)
         copick convert mesh2seg --invert -i "membrane:user1/manual-001" -o "membrane:mesh2seg/inverted-001@10.0"
 
+        \b
         # Convert all manual meshes using pattern matching with multilabel output
         copick convert mesh2seg -i "membrane:user1/manual-.*" -o "membrane:mesh2seg/from-mesh-{input_session_id}@10.0?multilabel=true"
+
+    See Also:
+
+        \b
+        copick convert seg2mesh: the inverse conversion (segmentation back to a mesh)
+        copick convert mesh2picks: sample picks from a mesh surface
+        copick convert mesh2caps: extract the top/bottom caps of a slab box mesh
     """
     from copick_utils.converters.segmentation_from_mesh import segmentation_from_mesh_lazy_batch
 

--- a/src/copick_utils/cli/meshop.py
+++ b/src/copick_utils/cli/meshop.py
@@ -59,41 +59,39 @@ def meshop(
     """
     Perform boolean operations between meshes.
 
-    \b
+    Combine, subtract, or intersect mesh annotations across runs using boolean geometry.
+    Supported operations are `union` (combine matching meshes, accepts N>=1 inputs),
+    `difference` (first minus second, requires exactly 2 inputs), `intersection` (common
+    volume, requires exactly 2 inputs), `exclusion` (exclusive-or / XOR, requires exactly
+    2 inputs), and `concatenate` (simple concatenation without boolean ops, accepts N>=1
+    inputs).
+
+    Input meshes are selected by URI. Patterns use glob wildcards (`*` and `?`) by
+    default, or regular expressions when prefixed with `re:`. When a single -i flag is
+    given with a pattern, `union` and `concatenate` expand that pattern within each run
+    and merge all matching meshes, which is useful for combining multiple versions or
+    annotations per run.
+
     URI Format:
+
+        \b
         Meshes: object_name:user_id/session_id
 
-    \b
-    Pattern Support:
-        - Glob (default): Use * and ? wildcards (e.g., "membrane:user*/session-*")
-        - Regex: Prefix with 're:' (e.g., "re:membrane:user\\d+/session-\\d+")
-
-    \b
-    Operations:
-        - union: Combine meshes using boolean union - accepts N≥1 inputs
-        - difference: First minus second - requires exactly 2 inputs
-        - intersection: Common volume - requires exactly 2 inputs
-        - exclusion: Exclusive or (XOR) - requires exactly 2 inputs
-        - concatenate: Simple concatenation without boolean ops - accepts N≥1 inputs
-
-    \b
-    Single-Input Pattern Expansion (union & concatenate):
-        When providing a single -i flag with a pattern, union/concatenate operations
-        will expand the pattern within each run and merge all matching meshes.
-        This is useful for combining multiple versions/annotations within each run.
-
-    \b
     Examples:
+
+        \b
         # Single-input union: merge all matching meshes within each run
         copick logical meshop --operation union \\
             -i "membrane:user*/manual-*" \\
             -o "merged"
 
+        \b
         # Single-input concatenation: concatenate all matching meshes per run
         copick logical meshop --operation concatenate \\
             -i "part*:user1/session-*" \\
             -o "combined"
 
+        \b
         # N-way union with multiple -i flags (merge across different objects)
         copick logical meshop --operation union \\
             -i "membrane:user1/manual-*" \\
@@ -101,24 +99,33 @@ def meshop(
             -i "ribosome:user3/pred-*" \\
             -o "merged"
 
+        \b
         # N-way union with regex patterns
         copick logical meshop --operation union \\
             -i "re:membrane:user1/manual-\\d+" \\
             -i "re:vesicle:user2/auto-\\d+" \\
             -o "merged"
 
+        \b
         # 2-way difference (exactly 2 inputs required)
         copick logical meshop --operation difference \\
             -i "membrane:user1/manual-001" \\
             -i "mask:user1/mask-001" \\
             -o "membrane:meshop/masked"
 
+        \b
         # N-way concatenation with multiple -i flags
         copick logical meshop --operation concatenate \\
             -i "part1:user1/session" \\
             -i "part2:user1/session" \\
             -i "part3:user1/session" \\
             -o "combined"
+
+    See Also:
+
+        \b
+        copick convert mesh2caps: extract the top/bottom caps of a slab box built with meshop
+        copick logical clippicks: select picks by distance to a mesh produced here
     """
     logger = get_logger(__name__, debug=debug)
 

--- a/src/copick_utils/cli/picks2ellipsoid.py
+++ b/src/copick_utils/cli/picks2ellipsoid.py
@@ -79,21 +79,43 @@ def picks2ellipsoid(
     """
     Convert picks to ellipsoid meshes.
 
-    \b
+    Build an ellipsoid mesh for each pick (or for each cluster of picks), tessellating
+    the surface at the requested subdivision level. Picks can optionally be grouped first
+    with a clustering method (DBSCAN or k-means) so that one ellipsoid is fit per cluster,
+    and overlapping ellipsoids can be deduplicated by their center distance.
+
+    The result is written either as a single combined mesh per pick set or, with
+    `--individual-meshes`, as one mesh per instance (enabling the `{instance_id}`
+    placeholder in the output URI).
+
     URI Format:
+
+        \b
         Picks: object_name:user_id/session_id
         Meshes: object_name:user_id/session_id
 
-    \b
     Examples:
+
+        \b
         # Convert single pick set to single ellipsoid mesh
         copick convert picks2ellipsoid -i "ribosome:user1/manual-001" -o "ribosome:picks2ellipsoid/ellipsoid-001"
 
+        \b
         # Create individual ellipsoid meshes
-        copick convert picks2ellipsoid -i "ribosome:user1/manual-001" -o "ribosome:picks2ellipsoid/ellipsoid-{instance_id}" --individual-meshes
+        copick convert picks2ellipsoid -i "ribosome:user1/manual-001" \\
+            -o "ribosome:picks2ellipsoid/ellipsoid-{instance_id}" --individual-meshes
 
+        \b
         # Convert all manual picks using pattern matching
-        copick convert picks2ellipsoid -i "ribosome:user1/manual-.*" -o "ribosome:picks2ellipsoid/ellipsoid-{input_session_id}"
+        copick convert picks2ellipsoid -i "ribosome:user1/manual-.*" \\
+            -o "ribosome:picks2ellipsoid/ellipsoid-{input_session_id}"
+
+    See Also:
+
+        \b
+        copick convert picks2sphere: build sphere meshes from picks instead of ellipsoids
+        copick convert picks2mesh: build a general surface mesh from picks
+        copick convert mesh2caps: extract the top/bottom caps of a closed slab box mesh
     """
     from copick_utils.converters.ellipsoid_from_picks import ellipsoid_from_picks_lazy_batch
 

--- a/src/copick_utils/cli/picks2mesh.py
+++ b/src/copick_utils/cli/picks2mesh.py
@@ -16,7 +16,7 @@ from copick_utils.util.config_models import create_simple_config
 
 @click.command(
     context_settings={"show_default": True},
-    short_help="Convert picks to mesh using convex hull or alpha shapes.",
+    short_help="Convert picks to meshes using convex hull or alpha shapes.",
     no_args_is_help=True,
 )
 @add_config_option
@@ -74,34 +74,46 @@ def picks2mesh(
     """
     Convert picks to meshes using convex hull or alpha shapes.
 
-    \b
+    For each matched pick set, builds a single surface mesh that encloses the pick
+    coordinates. Two methods are supported: `convex_hull` wraps the points in their
+    tightest convex envelope, while `alpha_shape` (requires `--alpha`) yields a tighter,
+    possibly non-convex surface. Optional clustering (DBSCAN or KMeans) first splits the
+    picks into groups, and `--individual-meshes` writes one mesh per cluster/instance via
+    the `{instance_id}` placeholder.
+
+    Input and output URIs select picks and meshes by object name, user id and session id.
+    They support exact, glob, regex (`re:` prefix) and bare-wildcard matching, enabling
+    one-to-one, one-to-many and many-to-many conversions through `{input_session_id}` and
+    `{instance_id}` placeholders in the output URI.
+
     URI Format:
+
+        \b
         Picks: object_name:user_id/session_id
         Meshes: object_name:user_id/session_id
 
-    \b
-    Pattern Matching:
-        - Exact: "ribosome:user1/session1"
-        - Glob: "ribosome:user1/session*" or "ribosome:*/manual-*"
-        - Regex: "re:ribosome:user\\d+/session\\d+"
-        - Wildcard: "ribosome" (expands to "ribosome:*/*")
-
-    \b
-    Supports flexible input/output selection modes:
-        - One-to-one: exact session ID → exact session ID
-        - One-to-many: exact session ID → template with {instance_id}
-        - Many-to-many: pattern → template with {input_session_id} and {instance_id}
-
-    \b
     Examples:
-        # Convert single pick set to single mesh
+
+        \b
+        # Convert a single pick set to a single convex-hull mesh
         copick convert picks2mesh -i "ribosome:user1/manual-001" -o "ribosome:picks2mesh/mesh-001"
 
+        \b
         # Create individual meshes from clusters
-        copick convert picks2mesh -i "ribosome:user1/manual-001" -o "ribosome:picks2mesh/mesh-{instance_id}" --individual-meshes
+        copick convert picks2mesh -i "ribosome:user1/manual-001" \\
+            -o "ribosome:picks2mesh/mesh-{instance_id}" --individual-meshes
 
-        # Convert all manual picks using pattern matching
-        copick convert picks2mesh -i "ribosome:user1/manual-.*" -o "ribosome:picks2mesh/mesh-{input_session_id}"
+        \b
+        # Build alpha-shape surfaces for all manual picks via regex matching
+        copick convert picks2mesh --mesh-type alpha_shape --alpha 150 \\
+            -i "re:ribosome:user\\d+/manual-.*" -o "ribosome:picks2mesh/mesh-{input_session_id}"
+
+    See Also:
+
+        \b
+        copick convert picks2sphere: convert picks to sphere meshes instead
+        copick convert mesh2seg: voxelize the resulting mesh into a segmentation
+        copick convert mesh2caps: extract the top/bottom caps of a slab box mesh
     """
     from copick_utils.converters.mesh_from_picks import mesh_from_picks_lazy_batch
 

--- a/src/copick_utils/cli/picks2plane.py
+++ b/src/copick_utils/cli/picks2plane.py
@@ -66,21 +66,40 @@ def picks2plane(
     """
     Convert picks to plane meshes.
 
-    \b
+    Fits a best-fit plane through each set of picks and emits it as a rectangular planar
+    mesh sized to cover the points. The `--padding` factor scales the plane beyond the exact
+    point extent (1.0 = exact fit, >1.0 = larger plane).
+
+    Picks can be clustered first (DBSCAN or k-means) so that distinct groups of points each
+    get their own plane; combined with `--individual-meshes` this writes one mesh per cluster
+    using the `{instance_id}` placeholder in the output URI.
+
     URI Format:
+
+        \b
         Picks: object_name:user_id/session_id
         Meshes: object_name:user_id/session_id
 
-    \b
     Examples:
+
+        \b
         # Convert single pick set to single plane mesh
         copick convert picks2plane -i "membrane:user1/manual-001" -o "membrane:picks2plane/plane-001"
 
+        \b
         # Create individual plane meshes from clusters
-        copick convert picks2plane -i "membrane:user1/manual-001" -o "membrane:picks2plane/plane-{instance_id}" --individual-meshes
+        copick convert picks2plane -i "membrane:user1/manual-001" \\
+            -o "membrane:picks2plane/plane-{instance_id}" --individual-meshes
 
+        \b
         # Convert all manual picks using pattern matching
         copick convert picks2plane -i "membrane:user1/manual-.*" -o "membrane:picks2plane/plane-{input_session_id}"
+
+    See Also:
+
+        \b
+        copick convert picks2surface: fit a curved 2D surface mesh to the same picks
+        copick convert picks2mesh: build a convex-hull or alpha-shape mesh from picks
     """
     from copick_utils.converters.plane_from_picks import plane_from_picks_lazy_batch
 

--- a/src/copick_utils/cli/picks2seg.py
+++ b/src/copick_utils/cli/picks2seg.py
@@ -16,7 +16,7 @@ from copick_utils.util.config_models import create_simple_config
 
 @click.command(
     context_settings={"show_default": True},
-    short_help="Convert picks to segmentation.",
+    short_help="Convert picks to segmentation volumes by painting spheres.",
     no_args_is_help=True,
 )
 @add_config_option
@@ -53,18 +53,40 @@ def picks2seg(
     """
     Convert picks to segmentation volumes by painting spheres.
 
-    \b
+    Paints a solid sphere of the given `--radius` (in physical units) at every pick location into a
+    label segmentation, producing a dense volume from sparse point annotations. The output is sized
+    and aligned to the reference tomogram (`--tomo-type`) at the voxel spacing given in the output URI.
+
+    Both input and output URIs accept regex patterns and `{input_*}` templating, so many pick sets can
+    be painted in one call; runs are discovered and processed in parallel via `--workers`.
+
     URI Format:
+
+        \b
         Picks: object_name:user_id/session_id
         Segmentations: name:user_id/session_id@voxel_spacing
 
-    \b
     Examples:
-        # Convert single pick set to segmentation
+
+        \b
+        # Convert a single pick set to a segmentation
         copick convert picks2seg -i "ribosome:user1/manual-001" -o "ribosome:picks2seg/painted-001@10.0"
 
-        # Convert all manual picks using pattern matching
+        \b
+        # Convert all manual picks using pattern matching, keeping the source session id
         copick convert picks2seg -i "ribosome:user1/manual-.*" -o "ribosome:picks2seg/painted-{input_session_id}@10.0"
+
+        \b
+        # Paint larger spheres against a denoised reference tomogram
+        copick convert picks2seg --radius 80 --tomo-type denoised \\
+            -i "ribosome:user1/manual-001" -o "ribosome:picks2seg/painted-001@10.0"
+
+    See Also:
+
+        \b
+        copick convert seg2picks: the inverse — extract picks from a segmentation
+        copick convert mesh2seg: paint a segmentation from a mesh instead of picks
+        copick convert picks2mesh: build a mesh from picks instead of a segmentation
     """
     from copick_utils.converters.segmentation_from_picks import segmentation_from_picks_lazy_batch
 

--- a/src/copick_utils/cli/picks2sphere.py
+++ b/src/copick_utils/cli/picks2sphere.py
@@ -79,21 +79,44 @@ def picks2sphere(
     """
     Convert picks to sphere meshes.
 
-    \b
+    Fits a sphere to the pick points using a least-squares fit and emits a triangulated icosphere
+    mesh at the fitted center and radius. The `--subdivisions` option controls the icosphere
+    tessellation, trading smoothness against face count.
+
+    When `--use-clustering` is set, the picks are grouped first; with `--all-clusters` one sphere is
+    fit per cluster, otherwise only the largest cluster is used. Overlapping spheres can be merged
+    with `--deduplicate-spheres` (centers closer than `--min-sphere-distance`, defaulting to half the
+    average radius, are treated as duplicates and volume-averaged). By default a single combined mesh
+    is written per run; `--individual-meshes` instead writes one mesh per sphere using the
+    `{instance_id}` placeholder in the output session id.
+
     URI Format:
+
+        \b
         Picks: object_name:user_id/session_id
         Meshes: object_name:user_id/session_id
 
-    \b
     Examples:
-        # Convert single pick set to single sphere mesh
+
+        \b
+        # Convert a single pick set to one sphere mesh
         copick convert picks2sphere -i "ribosome:user1/manual-001" -o "ribosome:picks2sphere/sphere-001"
 
-        # Create individual sphere meshes
-        copick convert picks2sphere -i "ribosome:user1/manual-001" -o "ribosome:picks2sphere/sphere-{instance_id}" --individual-meshes
+        \b
+        # Cluster the picks and write one sphere mesh per instance
+        copick convert picks2sphere --use-clustering --all-clusters --individual-meshes \\
+            -i "ribosome:user1/manual-001" -o "ribosome:picks2sphere/sphere-{instance_id}"
 
+        \b
         # Convert all manual picks using pattern matching
         copick convert picks2sphere -i "ribosome:user1/manual-.*" -o "ribosome:picks2sphere/sphere-{input_session_id}"
+
+    See Also:
+
+        \b
+        copick convert picks2ellipsoid: anisotropic alternative producing ellipsoid meshes
+        copick convert picks2mesh: build a mesh from picks via convex hull or alpha shapes
+        copick convert mesh2picks: inverse conversion, sampling picks back from a mesh
     """
     from copick_utils.converters.sphere_from_picks import sphere_from_picks_lazy_batch
 

--- a/src/copick_utils/cli/picks2surface.py
+++ b/src/copick_utils/cli/picks2surface.py
@@ -73,21 +73,44 @@ def picks2surface(
     """
     Convert picks to 2D surface meshes.
 
-    \b
+    Fit an open 2D surface (a sheet-like membrane) through a set of point picks and write it as
+    a mesh. This is useful for reconstructing membranes or other laminar structures sampled by
+    individual particle picks.
+
+    Three surface-fitting methods are supported via `--surface-method`: `delaunay` (Delaunay
+    triangulation of the points), `rbf` (radial-basis-function interpolation onto a regular grid),
+    and `grid` (gridded surface at `--grid-resolution`). Optional clustering can split the picks
+    into separate instances first; with `--individual-meshes` each cluster is written to its own
+    mesh using the `{instance_id}` placeholder in the output session id.
+
     URI Format:
+
+        \b
         Picks: object_name:user_id/session_id
         Meshes: object_name:user_id/session_id
 
-    \b
     Examples:
+
+        \b
         # Convert single pick set to single surface mesh
         copick convert picks2surface -i "membrane:user1/manual-001" -o "membrane:picks2surface/surface-001"
 
+        \b
         # Create individual surface meshes from clusters
-        copick convert picks2surface -i "membrane:user1/manual-001" -o "membrane:picks2surface/surface-{instance_id}" --individual-meshes
+        copick convert picks2surface --individual-meshes \\
+            -i "membrane:user1/manual-001" -o "membrane:picks2surface/surface-{instance_id}"
 
+        \b
         # Convert all manual picks using pattern matching
         copick convert picks2surface -i "membrane:user1/manual-.*" -o "membrane:picks2surface/surface-{input_session_id}"
+
+    See Also:
+
+        \b
+        copick convert picks2plane: fit a single flat plane mesh to picks
+        copick convert picks2mesh: build a convex-hull or alpha-shape mesh from picks
+        copick convert mesh2caps: extract the top/bottom cap surfaces of a slab box mesh
+        copick logical clippicks: select picks by distance to a reference surface
     """
     from copick_utils.converters.surface_from_picks import surface_from_picks_lazy_batch
 

--- a/src/copick_utils/cli/picksin.py
+++ b/src/copick_utils/cli/picksin.py
@@ -50,23 +50,35 @@ def picksin(
     """
     Filter picks to include only those inside a reference volume.
 
-    \b
+    The reference volume can be either a watertight mesh or a segmentation (provide exactly one
+    via `--ref-mesh` or `--ref-seg`). Each input pick is tested against the volume and only those
+    whose coordinates fall inside it are written to the output. This is the inverse of
+    `copick logical picksout`, which keeps the picks that fall outside the volume instead.
+
     URI Format:
+
+        \b
         Picks: object_name:user_id/session_id
         Meshes: object_name:user_id/session_id
         Segmentations: name:user_id/session_id@voxel_spacing
 
-    \b
-    The reference volume can be either a watertight mesh or a segmentation.
-    Only picks that fall inside the reference volume will be kept.
-
-    \b
     Examples:
-        # Include only picks inside reference mesh
-        copick logical picksin -i "ribosome:user1/all-001" -rm "boundary:user1/boundary-001" -o "ribosome:picksin/inside-001"
 
-        # Include only picks inside segmentation
-        copick logical picksin -i "ribosome:user1/all-001" -rs "mask:user1/mask-001@10.0" -o "ribosome:picksin/inside-001"
+        \b
+        # Include only picks inside a reference mesh
+        copick logical picksin -i "ribosome:user1/all-001" -rm "boundary:user1/boundary-001" \\
+            -o "ribosome:picksin/inside-001"
+
+        \b
+        # Include only picks inside a segmentation
+        copick logical picksin -i "ribosome:user1/all-001" -rs "mask:user1/mask-001@10.0" \\
+            -o "ribosome:picksin/inside-001"
+
+    See Also:
+
+        \b
+        copick logical picksout: keep picks that fall outside the reference volume instead
+        copick logical clippicks: select picks by distance to a reference mesh
     """
     from copick_utils.logical.point_operations import picks_inclusion_by_mesh_lazy_batch
 

--- a/src/copick_utils/cli/picksout.py
+++ b/src/copick_utils/cli/picksout.py
@@ -52,23 +52,35 @@ def picksout(
     """
     Filter picks to exclude those inside a reference volume.
 
-    \b
+    The reference volume can be either a watertight mesh or a segmentation (provide exactly one
+    via `--ref-mesh` or `--ref-seg`). Each input pick is tested against the volume and only those
+    whose coordinates fall outside it are written to the output. This is the inverse of
+    `copick logical picksin`, which keeps the picks that fall inside the volume instead.
+
     URI Format:
+
+        \b
         Picks: object_name:user_id/session_id
         Meshes: object_name:user_id/session_id
         Segmentations: name:user_id/session_id@voxel_spacing
 
-    \b
-    The reference volume can be either a watertight mesh or a segmentation.
-    Picks that fall inside the reference volume will be removed.
-
-    \b
     Examples:
-        # Exclude picks inside reference mesh
-        copick logical picksout -i "ribosome:user1/all-001" -rm "boundary:user1/boundary-001" -o "ribosome:picksout/outside-001"
 
-        # Exclude picks inside segmentation
-        copick logical picksout -i "ribosome:user1/all-001" -rs "mask:user1/mask-001@10.0" -o "ribosome:picksout/outside-001"
+        \b
+        # Exclude picks inside a reference mesh
+        copick logical picksout -i "ribosome:user1/all-001" -rm "boundary:user1/boundary-001" \\
+            -o "ribosome:picksout/outside-001"
+
+        \b
+        # Exclude picks inside a segmentation
+        copick logical picksout -i "ribosome:user1/all-001" -rs "mask:user1/mask-001@10.0" \\
+            -o "ribosome:picksout/outside-001"
+
+    See Also:
+
+        \b
+        copick logical picksin: keep picks that fall inside the reference volume instead
+        copick logical clippicks: select picks by distance to a reference mesh
     """
     from copick_utils.logical.point_operations import picks_exclusion_by_mesh_lazy_batch
 

--- a/src/copick_utils/cli/rescale.py
+++ b/src/copick_utils/cli/rescale.py
@@ -67,32 +67,46 @@ def rescale(
 
     Resamples segmentation data using nearest-neighbor interpolation (default) to
     preserve label integrity. Supports both upscaling (finer spacing) and downscaling
-    (coarser spacing). When --tomo-type is provided, the output shape is matched to
+    (coarser spacing). When `--tomo-type` is provided, the output shape is matched to
     an existing tomogram at the target spacing for exact alignment.
 
-    \b
     URI Format:
+
+        \b
         Segmentations: name:user_id/session_id@voxel_spacing
 
-    \b
     Examples:
+
+        \b
         # Upscale: 10 angstrom -> 5 angstrom
         copick process rescale -i "membrane:user1/auto@10.0" -o "membrane:rescale/0@5.0"
 
+        \b
         # Downscale: 5 angstrom -> 20 angstrom
         copick process rescale -i "membrane:user1/manual@5.0" -o "membrane:rescale/0@20.0"
 
+        \b
         # Match tomogram shape exactly
         copick process rescale -i "membrane:user1/auto@10.0" -o "membrane:rescale/0@5.0" --tomo-type wbp
 
+        \b
         # Explicit target spacing (when output URI uses smart defaults)
         copick process rescale -i "membrane:user1/auto@10.0" -o "membrane_rescaled" --target-voxel-spacing 5.0
 
+        \b
         # Rescale specific runs
         copick process rescale -i "organelle:pred/auto@10.0" -o "organelle:rescale/0@7.5" -r run1 -r run2
 
+        \b
         # Linear interpolation (for non-label float data)
         copick process rescale -i "density:user1/auto@10.0" -o "density:rescale/0@5.0" --order 1
+
+    See Also:
+
+        \b
+        copick process expand_labels: fill label holes/gaps that nearest-neighbor resampling can introduce
+        copick convert mesh2seg: rasterize meshes into a segmentation at a target voxel spacing
+        copick process combine: merge single-label segmentations into one multilabel volume
     """
     from copick_utils.process.rescale import rescale_lazy_batch
 

--- a/src/copick_utils/cli/seg2mesh.py
+++ b/src/copick_utils/cli/seg2mesh.py
@@ -16,7 +16,7 @@ from copick_utils.util.config_models import create_simple_config
 
 @click.command(
     context_settings={"show_default": True},
-    short_help="Convert segmentation to mesh.",
+    short_help="Convert segmentation volumes to meshes using marching cubes.",
     no_args_is_help=True,
 )
 @add_config_option
@@ -55,18 +55,43 @@ def seg2mesh(
     """
     Convert segmentation volumes to meshes using marching cubes.
 
-    \b
+    Runs the marching cubes algorithm on one or more segmentation volumes to produce
+    triangulated surface meshes. Input segmentations are selected by URI (with optional
+    regex/pattern matching on the user and session ids), and the resulting meshes are
+    written using a templated output URI.
+
+    Use `--individual-meshes` to emit a separate mesh per instance label (this enables the
+    `{instance_id}` placeholder in the output URI); otherwise a single mesh is produced per
+    matched segmentation. The `--level` and `--step-size` options control the marching cubes
+    iso-level and the sampling step (larger steps are faster but coarser).
+
     URI Format:
+
+        \b
         Segmentations: name:user_id/session_id@voxel_spacing
         Meshes: object_name:user_id/session_id
 
-    \b
     Examples:
+
+        \b
         # Convert single segmentation to mesh
         copick convert seg2mesh -i "membrane:user1/manual-001@10.0" -o "membrane:seg2mesh/from-seg-001"
 
+        \b
         # Convert all manual segmentations using pattern matching
         copick convert seg2mesh -i "membrane:user1/manual-.*@10.0" -o "membrane:seg2mesh/from-seg-{input_session_id}"
+
+        \b
+        # Emit a separate mesh per instance label
+        copick convert seg2mesh --individual-meshes \\
+            -i "membrane:user1/manual-001@10.0" -o "membrane:seg2mesh/inst-{instance_id}"
+
+    See Also:
+
+        \b
+        copick convert mesh2seg: rasterize a mesh back into a segmentation volume
+        copick convert mesh2caps: extract the top/bottom caps of a slab box mesh
+        copick convert seg2picks: convert a segmentation into picks
     """
     from copick_utils.converters.mesh_from_segmentation import mesh_from_segmentation_lazy_batch
 

--- a/src/copick_utils/cli/seg2picks.py
+++ b/src/copick_utils/cli/seg2picks.py
@@ -47,20 +47,45 @@ def seg2picks(
     debug,
 ):
     """
-    Convert segmentation volumes to picks by extracting centroids.
+    Convert segmentation to picks.
 
-    \b
+    Extracts particle centroids from segmentation volumes and writes them as picks. The chosen
+    label (`--segmentation-idx`) is split into connected components, each component becomes one
+    point at its centroid, and a maximum filter (`--maxima-filter-size`) controls how nearby
+    maxima are merged. Components outside the `--min-particle-size`/`--max-particle-size` voxel
+    range are discarded.
+
+    The input pattern and output template support regex matching and `{input_*}` substitutions,
+    so a single invocation can fan out across many runs and sessions in parallel.
+
     URI Format:
+
+        \b
         Segmentations: name:user_id/session_id@voxel_spacing
         Picks: object_name:user_id/session_id
 
-    \b
     Examples:
-        # Convert single segmentation to picks
+
+        \b
+        # Convert a single segmentation to picks
         copick convert seg2picks -i "membrane:user1/manual-001@10.0" -o "membrane:seg2picks/centroid-001"
 
+        \b
         # Convert all manual segmentations using pattern matching
-        copick convert seg2picks -i "membrane:user1/manual-.*@10.0" -o "membrane:seg2picks/centroid-{input_session_id}"
+        copick convert seg2picks -i "membrane:user1/manual-.*@10.0" \\
+            -o "membrane:seg2picks/centroid-{input_session_id}"
+
+        \b
+        # Pick a specific label and filter by particle size
+        copick convert seg2picks --segmentation-idx 1 --min-particle-size 50 --max-particle-size 5000 \\
+            -i "membrane:user1/manual-001@10.0" -o "membrane:seg2picks/centroid-001"
+
+    See Also:
+
+        \b
+        copick convert picks2seg: rasterize picks back into a segmentation (the inverse)
+        copick convert seg2mesh: convert the same segmentation into a surface mesh instead
+        copick convert mesh2picks: sample picks from a mesh instead of a segmentation
     """
     from copick_utils.converters.picks_from_segmentation import picks_from_segmentation_lazy_batch
 

--- a/src/copick_utils/cli/seg_stats.py
+++ b/src/copick_utils/cli/seg_stats.py
@@ -70,29 +70,42 @@ def seg_stats(
 
     This command identifies connected components in a segmentation and reports
     the volume of each component (in voxels and cubic angstroms), grouped by label.
-    Output can be a CSV file or a histogram plot.
+    Output can be a CSV file or a histogram plot, and you can choose the voxel
+    connectivity (face, face-edge, or all) used to define components.
 
-    \b
     URI Format:
+
+        \b
         Segmentations: name:user_id/session_id@voxel_spacing
         Voxel spacing is optional — omit to match all voxel spacings.
 
-    \b
     Examples:
+
+        \b
         # Export component stats as CSV
         copick process seg-stats -i "membrane:user1/auto-001@10.0" -f csv -op ./membrane_stats.csv
 
+        \b
         # Analyze without specifying voxel spacing (matches all)
         copick process seg-stats -i "proofread:napari/manual" -f csv -op ./stats.csv
 
+        \b
         # Create a histogram plot as HTML (interactive)
         copick process seg-stats -i "membrane:user1/auto-001@10.0" -f plot -op ./membrane_hist.html
 
+        \b
         # Create a histogram plot as PDF
         copick process seg-stats -i "organelle:user1/pred@10.0" -f plot -op ./organelle_hist.pdf
 
+        \b
         # Analyze specific runs and export as PNG
         copick process seg-stats -i "membrane:user1/auto-001@10.0" -f plot -op ./stats.png -r run1 -r run2
+
+    See Also:
+
+        \b
+        copick process filter-components: remove connected components by the size thresholds chosen here
+        copick process separate-components: relabel each connected component as a distinct class
     """
     from copick_utils.process.seg_stats import export_stats_csv, export_stats_plot, seg_stats_batch
 

--- a/src/copick_utils/cli/segop.py
+++ b/src/copick_utils/cli/segop.py
@@ -59,39 +59,36 @@ def segop(
     """
     Perform boolean operations between segmentations.
 
-    \b
+    Combine multiple segmentations using boolean set operations. Every input is first
+    converted to a binary mask, then combined with the chosen operation. The voxel spacing
+    given by `--voxel-spacing` applies globally to all inputs and to the output.
+
+    Supported operations: `union` combines segmentations (logical OR) and accepts N>=1
+    inputs; `difference` subtracts the second input from the first and requires exactly 2
+    inputs; `intersection` keeps voxels common to both inputs (logical AND) and requires
+    exactly 2 inputs; `exclusion` keeps voxels present in exactly one input (XOR) and
+    requires exactly 2 inputs.
+
+    Input URIs support glob wildcards (`*` and `?`) by default, or regular expressions when
+    prefixed with `re:` (for example `re:membrane:user\\d+/session-\\d+`). When a single `-i`
+    flag is given with a pattern, `union` expands the pattern within each run and merges every
+    matching segmentation, which is useful for combining multiple versions or annotations
+    within each run.
+
     URI Format:
-        Segmentations: name:user_id/session_id (voxel spacing via --voxel-spacing)
 
-    \b
-    Pattern Support:
-        - Glob (default): Use * and ? wildcards (e.g., "membrane:user*/session-*")
-        - Regex: Prefix with 're:' (e.g., "re:membrane:user\\d+/session-\\d+")
+        \b
+        Segmentations: name:user_id/session_id (voxel spacing supplied via --voxel-spacing)
 
-    \b
-    Operations:
-        - union: Combine segmentations (logical OR) - accepts N≥1 inputs
-        - difference: First minus second - requires exactly 2 inputs
-        - intersection: Common voxels (logical AND) - requires exactly 2 inputs
-        - exclusion: Exclusive or (XOR) - requires exactly 2 inputs
-
-    \b
-    Note: All segmentations are converted to binary for boolean operations.
-    Voxel spacing applies globally to all inputs and output.
-
-    \b
-    Single-Input Pattern Expansion (union only):
-        When providing a single -i flag with a pattern, the union operation will
-        expand the pattern within each run and merge all matching segmentations.
-        This is useful for combining multiple versions/annotations within each run.
-
-    \b
     Examples:
+
+        \b
         # Single-input union: merge all matching segmentations within each run
         copick logical segop --operation union -vs 10.0 \\
             -i "membrane:user*/manual-*" \\
             -o "merged"
 
+        \b
         # N-way union with multiple -i flags (merge across different objects)
         copick logical segop --operation union -vs 10.0 \\
             -i "membrane:user1/manual-*" \\
@@ -99,17 +96,25 @@ def segop(
             -i "ribosome:user3/pred-*" \\
             -o "merged"
 
+        \b
         # N-way union with regex patterns
         copick logical segop --operation union -vs 10.0 \\
             -i "re:membrane:user1/manual-\\d+" \\
             -i "re:vesicle:user2/auto-\\d+" \\
             -o "merged"
 
+        \b
         # 2-way difference (exactly 2 inputs required)
         copick logical segop --operation difference -vs 10.0 \\
             -i "membrane:user1/manual-001" \\
             -i "mask:user1/mask-001" \\
             -o "membrane:segop/masked"
+
+    See Also:
+
+        \b
+        copick logical meshop: the same boolean operations applied to meshes
+        copick logical clipseg: limit segmentation voxels by distance to a reference
     """
     logger = get_logger(__name__, debug=debug)
 

--- a/src/copick_utils/cli/separate_components.py
+++ b/src/copick_utils/cli/separate_components.py
@@ -57,27 +57,42 @@ def separate_components(
     output_uri,
     debug,
 ):
-    """Separate connected components in segmentations into individual segmentations.
+    """Separate connected components in segmentations.
 
-    \b
+    Connected-component analysis splits a segmentation into individual segmentations, one per
+    connected region. Connectivity can be `face` (6-connected), `face-edge` (18-connected), or
+    `all` (26-connected), and components smaller than `--min-size` (in cubic angstroms) are dropped.
+
+    For multilabel segmentations the analysis is performed on each label separately. Output
+    segmentations use the `{instance_id}` placeholder for auto-numbering (e.g. `inst-0`, `inst-1`).
+
     URI Format:
+
+        \b
         Segmentations: name:user_id/session_id@voxel_spacing
 
-    \b
-    For multilabel segmentations, connected components analysis is performed on each
-    label separately. Output segmentations use {instance_id} placeholder for auto-numbering
-    (e.g., "inst-0", "inst-1", etc.).
-
-    \b
     Examples:
+
+        \b
         # Separate components with smart defaults (auto user_id and session template)
-        copick process separate_components -i "membrane:user1/manual-001@10.0" -o "{instance_id}"
+        copick process separate-components -i "membrane:user1/manual-001@10.0" -o "{instance_id}"
 
+        \b
         # Custom session prefix
-        copick process separate_components -i "membrane:user1/manual-001@10.0" -o "membrane:components/inst-{instance_id}"
+        copick process separate-components -i "membrane:user1/manual-001@10.0" \\
+            -o "membrane:components/inst-{instance_id}"
 
+        \b
         # Full URI specification
-        copick process separate_components -i "membrane:user1/manual-001@10.0" -o "membrane:components/comp-{instance_id}@10.0"
+        copick process separate-components -i "membrane:user1/manual-001@10.0" \\
+            -o "membrane:components/comp-{instance_id}@10.0"
+
+    See Also:
+
+        \b
+        copick process filter-components: drop or keep components by size instead of splitting them
+        copick process seg-stats: report connected-component size statistics before separating
+        copick process split: split a multilabel segmentation into single-class segmentations
     """
     from copick_utils.process.connected_components import separate_components_lazy_batch
 

--- a/src/copick_utils/cli/skeletonize.py
+++ b/src/copick_utils/cli/skeletonize.py
@@ -11,7 +11,7 @@ from copick_utils.util.config_models import create_simple_config
 
 @click.command(
     context_settings={"show_default": True},
-    short_help="3D skeletonization of segmentations.",
+    short_help="Skeletonize segmentations in 3D using pattern matching.",
     no_args_is_help=True,
 )
 @add_config_option
@@ -71,24 +71,44 @@ def skeletonize(
     output_uri,
     debug,
 ):
-    """3D skeletonization of segmentations using pattern matching.
+    """Skeletonize segmentations in 3D using pattern matching.
 
-    \b
+    Reduces each input segmentation to a 1-voxel-wide medial skeleton, exposing the
+    centerlines of the objects it contains. Two backends are available: `skimage`
+    (scikit-image 3D thinning) and `distance_transform` (local maxima of the
+    Euclidean distance transform).
+
+    The input session ID is treated as a regex, so a single invocation can skeletonize
+    many segmentations at once. This pairs naturally with the output of connected-component
+    separation (e.g. pattern `inst-.*` to match `inst-0`, `inst-1`, etc.). Optional cleanup
+    removes small objects before thinning and prunes short spur branches afterwards.
+
     URI Format:
-        Segmentations: name:user_id/session_id@voxel_spacing
 
     \b
-    This command can process multiple segmentations by matching session IDs against
-    a pattern. This is useful for processing the output of connected components
-    separation (e.g., pattern "inst-.*" to match "inst-0", "inst-1", etc.).
+    Segmentations: name:user_id/session_id@voxel_spacing
 
-    \b
     Examples:
-        # Skeletonize exact match
-        copick process skeletonize -i "membrane:user1/inst-0@10.0" -o "membrane:skel/skel-0@10.0"
 
-        # Skeletonize all instances using pattern
-        copick process skeletonize -i "membrane:user1/inst-.*@10.0" -o "membrane:skel/skel-{input_session_id}@10.0"
+    \b
+    # Skeletonize a single segmentation (exact session match)
+    copick process skeletonize -i "membrane:user1/inst-0@10.0" -o "membrane:skel/skel-0@10.0"
+
+    \b
+    # Skeletonize every instance matched by a session-ID pattern
+    copick process skeletonize -i "membrane:user1/inst-.*@10.0" \\
+        -o "membrane:skel/skel-{input_session_id}@10.0"
+
+    \b
+    # Use the distance-transform backend and keep short branches
+    copick process skeletonize --method distance_transform --keep-short-branches \\
+        -i "membrane:user1/inst-.*@10.0" -o "membrane:skel/skel-{input_session_id}@10.0"
+
+    See Also:
+
+    \b
+    copick process separate-components: split a segmentation into the inst-* instances skeletonized here
+    copick process filter-components: drop small connected components before skeletonizing
     """
     from copick_utils.process.skeletonize import skeletonize_lazy_batch
 

--- a/src/copick_utils/cli/split_labels.py
+++ b/src/copick_utils/cli/split_labels.py
@@ -12,7 +12,7 @@ from copick_utils.cli.util import add_input_option, add_workers_option
 
 @click.command(
     context_settings={"show_default": True},
-    short_help="Split multilabel segmentations into single-class segmentations.",
+    short_help="Split multilabel segmentations into single-class masks.",
     no_args_is_help=True,
 )
 @add_config_option
@@ -53,35 +53,55 @@ def split(
     debug,
 ):
     """
-    Split multilabel segmentations into individual single-class binary segmentations.
+    Split multilabel segmentations into single-class masks.
 
     This command takes a multilabel segmentation and creates separate binary segmentations
     for each label value. Each output segmentation is named after the corresponding
-    PickableObject (as defined in the copick config) and uses the same session ID as
-    the input.
+    PickableObject (as defined in the copick config) and uses the same session ID as the
+    input.
 
-    \b
+    By default the object name for each label value is resolved from the pickable-objects
+    config. Pass --labels with an explicit 'name:value,...' map when the segmentation's label
+    values do not match the config object labels; only the listed values are then split. The
+    input URI must name an exact segmentation (no wildcards) and include a voxel spacing.
+
     URI Format:
+
+        \b
         Segmentations: name:user_id/session_id@voxel_spacing
 
-    \b
     Label-to-Object Mapping:
+
+        \b
         The tool looks up each label value in the pickable_objects configuration
         and uses the object name for the output segmentation:
         - Label 1 (ribosome) → ribosome:split/session-001@10.0
         - Label 2 (membrane) → membrane:split/session-001@10.0
         - Label 3 (proteasome) → proteasome:split/session-001@10.0
 
-    \b
     Examples:
+
+        \b
         # Split multilabel segmentation (outputs named by pickable objects)
         copick process split -i "predictions:model/run-001@10.0"
 
+        \b
         # Split with custom output user ID
         copick process split -i "classes:annotator/manual@10.0" --output-user-id "per-class"
 
+        \b
         # Process specific runs only
-        copick process split -i "labels:*/*@10.0" --run-names TS_001 --run-names TS_002
+        copick process split -i "labels:curator/manual@10.0" --run-names TS_001 --run-names TS_002
+
+        \b
+        # Split only specific label values with an explicit name:value map
+        copick process split -i "predictions:model/run-001@10.0" --labels "sample:1,vacuum:2"
+
+    See Also:
+
+        \b
+        copick process combine: the inverse operation (merge single-label segmentations into a multilabel volume)
+        copick convert seg2picks: extract picks from each resulting single-class segmentation
     """
 
     logger = get_logger(__name__, debug=debug)

--- a/src/copick_utils/cli/thickness_filter.py
+++ b/src/copick_utils/cli/thickness_filter.py
@@ -64,20 +64,30 @@ def thickness_filter(
 
     For multilabel segmentations, each label is filtered independently.
 
-    \b
     URI Format:
+
+        \b
         Segmentations: name:user_id/session_id@voxel_spacing
 
-    \b
     Examples:
+
+        \b
         # Remove membrane regions thinner than 50 Å
         copick process thickness-filter -i "membrane:user1/auto-001@10.0" -o "membrane_thick" --min-thickness 50.0
 
+        \b
         # Filter by voxel diameters instead of angstroms
         copick process thickness-filter -i "membrane:user1/auto-001@10.0" -o "membrane_thick" --min-thickness 5 --thickness-unit voxel
 
+        \b
         # Process specific runs with regex pattern
         copick process thickness-filter -i "membrane:user1/.*@10.0" -o "membrane_thick" --min-thickness 40.0 -r run001 -r run002
+
+    See Also:
+
+        \b
+        copick process filter-components: remove connected components below a size threshold
+        copick process expand-labels: grow labels to fill holes left after filtering
     """
     from copick_utils.process.thickness_filter import thickness_filter_lazy_batch
 

--- a/src/copick_utils/cli/validbox.py
+++ b/src/copick_utils/cli/validbox.py
@@ -52,23 +52,36 @@ def validbox(
     """
     Generate valid area box meshes for tomographic reconstructions.
 
-    \b
+    Creates box meshes representing the valid imaging area of tomographic
+    reconstructions. The box dimensions are derived from the tomogram voxel
+    dimensions and can be optionally rotated around the Z-axis, which is useful
+    when the specimen was imaged at an in-plane tilt.
+
+    The resulting slab mesh can be passed downstream to `copick convert mesh2caps`
+    (to keep only the top/bottom caps) and to `copick logical clippicks` (to
+    select particles inside the valid imaging volume).
+
     URI Format:
+
+        \b
         Meshes: object_name:user_id/session_id
         Tomograms: tomo_type@voxel_spacing
 
-    \b
-    Creates box meshes representing the valid imaging area of tomographic
-    reconstructions. The box dimensions are based on the tomogram voxel dimensions
-    and can be optionally rotated around the Z-axis.
-
-    \b
     Examples:
+
+        \b
         # Generate validbox meshes for all runs
         copick process validbox --tomogram wbp@10.0 -o "validbox"
 
-        # Generate with rotation and specific tomogram type
+        \b
+        # Generate with rotation and a specific tomogram type
         copick process validbox -t imod@10.0 --angle 45.0 -o "validbox/rotated"
+
+    See Also:
+
+        \b
+        copick convert mesh2caps: extract the top/bottom caps of the validbox slab
+        copick logical clippicks: select picks inside the valid imaging volume
     """
     from copick_utils.process.validbox import validbox_batch
 

--- a/src/copick_utils/converters/segmentation_from_picks.py
+++ b/src/copick_utils/converters/segmentation_from_picks.py
@@ -20,25 +20,22 @@ def from_picks(
     label_value: int = 1,
     voxel_spacing: float = 10,
 ) -> np.ndarray:
-    """
-    Paints picks into a segmentation volume as spheres.
+    """Paint picks into a segmentation volume as spheres.
 
-    Parameters:
-    -----------
-    pick : copick.models.CopickPicks
-        Copick object containing `points`, where each point has a `location` attribute with `x`, `y`, `z` coordinates.
-    seg_volume : numpy.ndarray
-        3D segmentation volume (numpy array) where the spheres are painted. Shape should be (Z, Y, X).
-    radius : float, optional
-        The radius of the spheres to be inserted in physical units (not voxel units). Default is 10.0.
-    label_value : int, optional
-        The integer value used to label the sphere regions in the segmentation volume. Default is 1.
-    voxel_spacing : float, optional
-        The spacing of voxels in the segmentation volume, used to scale the radius of the spheres. Default is 10.
+    Each pick location is converted from physical units to voxel indices and a
+    solid sphere of `radius` is written into `seg_volume` with `label_value`.
+
+    Args:
+        pick: Copick picks whose `points` each carry a `location` with x, y, z
+            coordinates in physical units.
+        seg_volume: 3D segmentation volume to paint into, shape (Z, Y, X).
+        radius: Sphere radius in physical units (angstroms), not voxels.
+        label_value: Integer label written into the sphere regions.
+        voxel_spacing: Voxel spacing of `seg_volume`, used to scale the radius.
+
     Returns:
-    --------
-    numpy.ndarray
-        The modified segmentation volume with spheres inserted at pick locations.
+        The modified segmentation volume with spheres painted at the pick
+        locations.
     """
 
     def create_sphere(shape, center, radius, val):

--- a/src/copick_utils/io/readers.py
+++ b/src/copick_utils/io/readers.py
@@ -3,19 +3,24 @@ from copick.util.uri import resolve_copick_objects
 
 
 def tomogram(run, voxel_size: float = 10, algorithm: str = "wbp", raise_error: bool = False, verbose=True):
-    """
-    Reads a tomogram from a Copick run.
+    """Read a tomogram from a copick run as a NumPy array.
 
-    Parameters:
-    -----------
-    run: copick.Run
-    voxel_size: float
-    algorithm: str
-    raise_error: bool
-    verbose: bool
+    Resolves the tomogram `{algorithm}@{voxel_size}` for the run. If it is not
+    found, reports the available voxel spacings / algorithms (raising or printing
+    depending on `raise_error` / `verbose`).
+
+    Args:
+        run: The copick run to read from.
+        voxel_size: Voxel spacing to query, in angstroms.
+        algorithm: Tomogram algorithm / type to read (e.g. `wbp`).
+        raise_error: Raise `ValueError` if the tomogram is missing instead of
+            returning `None`.
+        verbose: Print a diagnostic message listing what is available when the
+            tomogram is missing.
+
     Returns:
-    --------
-    vol: np.ndarray - The tomogram.
+        The tomogram as a NumPy array of shape (Z, Y, X), or `None` if it is
+        missing and `raise_error` is False.
     """
 
     # Get the tomogram from the Copick URI
@@ -60,21 +65,26 @@ def tomogram(run, voxel_size: float = 10, algorithm: str = "wbp", raise_error: b
 
 
 def segmentation(run, voxel_spacing: float, name: str, user_id=None, session_id=None, raise_error=False, verbose=True):
-    """
-    Reads a segmentation from a Copick run.
+    """Read a segmentation from a copick run as a NumPy array.
 
-    Parameters:
-    -----------
-    run: copick.Run
-    voxel_spacing: float
-    name: str
-    user_id: str
-    session_id: str
-    raise_error: bool
-    verbose: bool
+    Resolves the segmentation matching `name` (optionally filtered by `user_id`
+    and `session_id`) at the given voxel spacing. If none matches, reports the
+    available segmentations.
+
+    Args:
+        run: The copick run to read from.
+        voxel_spacing: Voxel spacing of the segmentation, in angstroms.
+        name: Segmentation / pickable-object name.
+        user_id: Restrict to this user id (optional).
+        session_id: Restrict to this session id (optional).
+        raise_error: Raise `ValueError` if no segmentation matches instead of
+            returning `None`.
+        verbose: Print a diagnostic message listing what is available when no
+            segmentation matches.
+
     Returns:
-    --------
-    seg: np.ndarray - The segmentation.
+        The segmentation as a NumPy array of shape (Z, Y, X), or `None` if none
+        matches and `raise_error` is False.
     """
 
     # Construct the Target URI
@@ -130,22 +140,24 @@ def coordinates(
     raise_error: bool = False,
     verbose: bool = True,
 ):
-    """
-    Reads the coordinates of the picks from a Copick run.
+    """Read pick coordinates from a copick run as an array of voxel indices.
 
-    Parameters:
-    -----------
-    run: copick.Run
-    name: str
-    user_id: str
-    session_id: str
-    voxel_size: float
-    raise_error: bool
-    verbose: bool
+    Looks up the picks for `name` (optionally filtered by `user_id` and
+    `session_id`) and returns their locations divided by `voxel_size`. If several
+    pick sets match, the first is used; if none match, reports the available picks.
+
+    Args:
+        run: The copick run to read from.
+        name: Pickable-object / protein name.
+        user_id: Identifier of the user that generated the picks.
+        session_id: Identifier of the session that generated the picks (optional).
+        voxel_size: Voxel spacing used to scale physical coordinates to voxels.
+        raise_error: Raise `ValueError` if no picks match instead of returning `None`.
+        verbose: Print a diagnostic message when no picks (or several) match.
 
     Returns:
-    --------
-    coordinates: np.ndarray - The 3D coordinates of the picks in voxel space.
+        An (N, 3) array of (z, y, x) coordinates in voxel space, or `None` if no
+        picks match and `raise_error` is False.
     """
     # Retrieve the pick points associated with the specified object and user ID
     picks = run.get_picks(object_name=name, user_id=user_id, session_id=session_id)

--- a/src/copick_utils/io/writers.py
+++ b/src/copick_utils/io/writers.py
@@ -2,24 +2,16 @@ import numpy as np
 
 
 def tomogram(run, input_volume, voxel_size=10, algorithm="wbp"):
-    """
-    Writes a volumetric tomogram into an OME-Zarr format within a Copick directory.
+    """Write a volumetric tomogram into a copick run as OME-Zarr.
 
-    Parameters:
-    -----------
-    run : copick.Run
-        The current Copick run object.
-    input_volume : np.ndarray
-        The volumetric tomogram data to be written.
-    voxel_size : float, optional
-        The size of the voxels in physical units. Default is 10.
-    algorithm : str, optional
-        The tomographic reconstruction algorithm to use. Default is 'wbp'.
+    Reuses the voxel spacing and tomogram for `algorithm` if they exist, creating
+    them otherwise, then writes `input_volume` (building the multiscale pyramid).
 
-    Returns:
-    --------
-    copick.Tomogram
-        The created or modified tomogram object.
+    Args:
+        run: The copick run to write into.
+        input_volume: The tomogram volume to write, shape (Z, Y, X).
+        voxel_size: Voxel spacing in angstroms.
+        algorithm: Tomogram algorithm / type to write under (e.g. `wbp`).
     """
 
     # Retrieve or create voxel spacing
@@ -45,30 +37,20 @@ def segmentation(
     voxel_size=10,
     multilabel=True,
 ):
-    """
-    Writes a segmentation into an OME-Zarr format within a Copick directory.
+    """Write a segmentation into a copick run as OME-Zarr.
 
-    Parameters:
-    -----------
-    run : copick.Run
-        The current Copick run object.
-    seg_vol : np.ndarray
-        The segmentation data to be written.
-    user_id : str
-        The ID of the user creating the segmentation.
-    name : str, optional
-        The name of the segmentation dataset to be created or modified. Default is 'segmentation'.
-    session_id : str, optional
-        The session ID for this segmentation. Default is '0'.
-    voxel_size : float, optional
-        The size of the voxels in physical units. Default is 10.
-    multilabel : bool, optional
-        Whether the segmentation is a multilabel segmentation. Default is True.
+    Reuses an existing segmentation matching `name` / `user_id` / `session_id` at
+    the given voxel spacing if present, creating a new one otherwise, then writes
+    `seg_vol` as `uint8`.
 
-    Returns:
-    --------
-    copick.Segmentation
-        The created or modified segmentation object.
+    Args:
+        run: The copick run to write into.
+        seg_vol: The label volume to write, shape (Z, Y, X).
+        user_id: User id to attribute the segmentation to.
+        name: Segmentation name. Defaults to `segmentation`.
+        session_id: Session id for the segmentation. Defaults to `0`.
+        voxel_size: Voxel spacing in angstroms.
+        multilabel: Whether the segmentation holds multiple labels.
     """
 
     # Retrieve or create a segmentation


### PR DESCRIPTION
Ahead of copick-main docs rework, normalize docstrings to work with web-docs generator. 