### PR TITLE
fix: Fix skeletonize and seg2picks

### DIFF
--- a/src/copick_utils/converters/segmentation_from_picks.py
+++ b/src/copick_utils/converters/segmentation_from_picks.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Dict, Optional, Tuple
 import numpy as np
 import zarr
 from copick.util.log import get_logger
-from scipy.ndimage import zoom
 
 from copick_utils.converters.lazy_converter import create_lazy_batch_converter
 
@@ -90,15 +89,6 @@ def from_picks(
     return seg_volume
 
 
-def downsample_to_exact_shape(array: np.ndarray, target_shape: tuple) -> np.ndarray:
-    """
-    Downsamples a 3D array to match the target shape using nearest-neighbor interpolation.
-    Ensures that the resulting array has the exact target shape.
-    """
-    zoom_factors = [t / s for t, s in zip(target_shape, array.shape)]
-    return zoom(array, zoom_factors, order=0)
-
-
 def _create_segmentation_from_picks_legacy(
     radius: float,
     painting_segmentation_name: str,
@@ -157,48 +147,19 @@ def _create_segmentation_from_picks_legacy(
     else:
         seg = segs[0]
 
-    segmentation_group = zarr.open(seg.zarr(), mode="a")
-    highest_res_name = "0"
-
-    # Get the highest resolution dimensions and create a new array if necessary
+    # Paint the picks into a fresh full-resolution label volume.
     tomogram_zarr = zarr.open(tomogram.zarr(), "r")
-
-    highest_res_shape = tomogram_zarr[highest_res_name].shape
-    if highest_res_name not in segmentation_group:
-        segmentation_group.create(highest_res_name, shape=highest_res_shape, dtype=np.uint16, overwrite=True)
-
-    # Initialize or load the highest resolution array
-    highest_res_seg = segmentation_group[highest_res_name][:]
-    highest_res_seg.fill(0)
-
-    # Paint picks into the highest resolution array
+    highest_res_shape = tomogram_zarr["0"].shape
+    highest_res_seg = np.zeros(highest_res_shape, dtype=np.uint16)
     highest_res_seg = from_picks(pick_set, highest_res_seg, radius, pickable_object.label, voxel_spacing)
 
-    # Write back the highest resolution data
-    segmentation_group[highest_res_name][:] = highest_res_seg
-
-    # Downsample to create lower resolution scales
-    multiscale_metadata = tomogram_zarr.attrs.get("multiscales", [{}])[0].get("datasets", [])
-    for level_index, level_metadata in enumerate(multiscale_metadata):
-        if level_index == 0:
-            continue
-
-        level_name = level_metadata.get("path", str(level_index))
-        expected_shape = tuple(tomogram_zarr[level_name].shape)
-
-        # Compute scaling factors relative to the highest resolution shape
-        scaled_array = downsample_to_exact_shape(highest_res_seg, expected_shape)
-
-        # Create/overwrite the Zarr array for this level
-        segmentation_group.create_dataset(
-            level_name,
-            shape=expected_shape,
-            data=scaled_array,
-            dtype=np.uint16,
-            overwrite=True,
-        )
-
-        segmentation_group[level_name][:] = scaled_array
+    # Write through the copick API so the OME-Zarr ``multiscales`` group attributes
+    # (axes + coordinate transformations) are written alongside the data. The previous
+    # implementation created the level datasets directly and omitted these attributes,
+    # producing a segmentation that copick could read but OME-Zarr clients (e.g.
+    # ChimeraX) could not. Written single-level, matching copick's default and every
+    # other converter.
+    seg.from_numpy(highest_res_seg, dtype=np.uint16)
 
     return seg
 

--- a/src/copick_utils/process/skeletonize.py
+++ b/src/copick_utils/process/skeletonize.py
@@ -87,8 +87,15 @@ class TubeSkeletonizer3D:
             min_branch_length: Minimum length of branches to keep
         """
         if remove_short_branches and len(self.skeleton_coords) > 0:
-            # Remove small objects from skeleton
-            cleaned_skeleton = remove_small_objects(self.skeleton, min_size=min_branch_length)
+            # Remove small (spur) objects from the skeleton. Use full connectivity so a thin,
+            # diagonally-stepping centerline stays a single connected object — with the default
+            # face-connectivity it fragments into tiny pieces that are then all removed (newer
+            # scikit-image removes objects <= min_size), emptying the skeleton entirely.
+            cleaned_skeleton = remove_small_objects(
+                self.skeleton,
+                min_size=min_branch_length,
+                connectivity=self.skeleton.ndim,
+            )
             self.skeleton = cleaned_skeleton
             self.skeleton_coords = np.array(np.where(self.skeleton)).T
 


### PR DESCRIPTION
Fix skeletonization (correct scipy API use) and seg2picks (use modern copick API instead of own OME-Zarr implementation). 