### PR TITLE
feat: Normalize run options across copick-utils CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "copick>=1.23.1",
+    "copick>=1.26.0",
     "click",
     "click-option-group",
     "numpy",

--- a/src/copick_utils/cli/clipmesh.py
+++ b/src/copick_utils/cli/clipmesh.py
@@ -1,7 +1,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 
@@ -24,13 +24,8 @@ from copick_utils.util.config_models import create_reference_config
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input meshes.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_input_option("mesh")
 @optgroup.group("\nReference Options", help="Options for reference surface (provide mesh, segmentation, or tomogram).")
 @add_reference_mesh_option(required=False)

--- a/src/copick_utils/cli/clippicks.py
+++ b/src/copick_utils/cli/clippicks.py
@@ -3,7 +3,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 
@@ -26,13 +26,8 @@ from copick_utils.util.config_models import create_reference_config
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input picks.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_input_option("picks")
 @optgroup.group("\nReference Options", help="Options for reference surface (provide mesh, segmentation, or tomogram).")
 @add_reference_mesh_option(required=False)

--- a/src/copick_utils/cli/clipseg.py
+++ b/src/copick_utils/cli/clipseg.py
@@ -1,7 +1,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 
@@ -24,13 +24,8 @@ from copick_utils.util.config_models import create_reference_config
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input segmentations.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_input_option("segmentation")
 @optgroup.group("\nReference Options", help="Options for reference surface (provide mesh, segmentation, or tomogram).")
 @add_reference_mesh_option(required=False)

--- a/src/copick_utils/cli/combine_labels.py
+++ b/src/copick_utils/cli/combine_labels.py
@@ -3,7 +3,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 
@@ -17,13 +17,8 @@ from copick_utils.util.config_models import create_single_selector_config
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input segmentations.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_input_option("segmentation")
 @add_workers_option
 @optgroup.group("\nOutput Options", help="Options related to the output segmentation.")

--- a/src/copick_utils/cli/enclosed.py
+++ b/src/copick_utils/cli/enclosed.py
@@ -3,7 +3,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 
@@ -17,13 +17,8 @@ from copick_utils.util.config_models import create_dual_selector_config
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input segmentations.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_dual_input_options("segmentation")
 @optgroup.group("\nTool Options", help="Options related to this tool.")
 @optgroup.option(

--- a/src/copick_utils/cli/expand_labels.py
+++ b/src/copick_utils/cli/expand_labels.py
@@ -3,7 +3,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 
@@ -17,13 +17,8 @@ from copick_utils.util.config_models import create_simple_config
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input segmentation.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_input_option("segmentation")
 @optgroup.group("\nTool Options", help="Options related to this tool.")
 @optgroup.option(

--- a/src/copick_utils/cli/filter_components.py
+++ b/src/copick_utils/cli/filter_components.py
@@ -3,7 +3,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 
@@ -17,13 +17,8 @@ from copick_utils.util.config_models import create_simple_config
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input segmentation.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_input_option("segmentation")
 @optgroup.group("\nTool Options", help="Options related to this tool.")
 @optgroup.option(

--- a/src/copick_utils/cli/fit_spline.py
+++ b/src/copick_utils/cli/fit_spline.py
@@ -1,7 +1,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 
@@ -15,12 +15,8 @@ from copick_utils.util.config_models import create_simple_config
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input segmentation.")
-@optgroup.option(
-    "--run-names",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_input_option("segmentation")
 @optgroup.option(
     "--voxel-spacing",

--- a/src/copick_utils/cli/hull.py
+++ b/src/copick_utils/cli/hull.py
@@ -2,7 +2,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 
@@ -20,13 +20,8 @@ from copick_utils.util.config_models import create_simple_config
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input meshes.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_input_option("mesh")
 @optgroup.group("\nTool Options", help="Options related to this tool.")
 @optgroup.option(

--- a/src/copick_utils/cli/mesh2caps.py
+++ b/src/copick_utils/cli/mesh2caps.py
@@ -1,7 +1,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 
@@ -20,13 +20,8 @@ from copick_utils.util.config_models import create_simple_config
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input meshes.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_input_option("mesh")
 @optgroup.group("\nTool Options", help="Options related to this tool.")
 @add_cap_extraction_options

--- a/src/copick_utils/cli/mesh2picks.py
+++ b/src/copick_utils/cli/mesh2picks.py
@@ -3,7 +3,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 
@@ -17,13 +17,8 @@ from copick_utils.util.config_models import create_simple_config
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input meshes.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_input_option("mesh")
 @add_tomogram_option(required=True)
 @optgroup.group("\nTool Options", help="Options related to this tool.")

--- a/src/copick_utils/cli/mesh2seg.py
+++ b/src/copick_utils/cli/mesh2seg.py
@@ -1,7 +1,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 
@@ -20,13 +20,8 @@ from copick_utils.util.config_models import create_simple_config
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input meshes.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_input_option("mesh")
 @optgroup.group("\nTool Options", help="Options related to this tool.")
 @add_mesh_voxelization_options

--- a/src/copick_utils/cli/meshop.py
+++ b/src/copick_utils/cli/meshop.py
@@ -3,7 +3,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 
@@ -25,13 +25,8 @@ from copick_utils.util.config_models import (
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to input meshes.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_multi_input_options("mesh")
 @optgroup.group("\nTool Options", help="Options related to this tool.")
 @add_boolean_operation_option

--- a/src/copick_utils/cli/picks2ellipsoid.py
+++ b/src/copick_utils/cli/picks2ellipsoid.py
@@ -1,7 +1,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 
@@ -20,13 +20,8 @@ from copick_utils.util.config_models import create_simple_config
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input picks.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_input_option("picks")
 @optgroup.group("\nTool Options", help="Options related to this tool.")
 @optgroup.option(

--- a/src/copick_utils/cli/picks2mesh.py
+++ b/src/copick_utils/cli/picks2mesh.py
@@ -1,7 +1,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 
@@ -20,13 +20,8 @@ from copick_utils.util.config_models import create_simple_config
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input picks.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_input_option("picks")
 @optgroup.group("\nTool Options", help="Options related to this tool.")
 @optgroup.option(

--- a/src/copick_utils/cli/picks2plane.py
+++ b/src/copick_utils/cli/picks2plane.py
@@ -1,7 +1,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 
@@ -20,13 +20,8 @@ from copick_utils.util.config_models import create_simple_config
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input picks.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_input_option("picks")
 @optgroup.group("\nTool Options", help="Options related to this tool.")
 @optgroup.option(

--- a/src/copick_utils/cli/picks2seg.py
+++ b/src/copick_utils/cli/picks2seg.py
@@ -1,7 +1,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 
@@ -20,13 +20,8 @@ from copick_utils.util.config_models import create_simple_config
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input picks.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_input_option("picks")
 @optgroup.group("\nTool Options", help="Options related to this tool.")
 @add_picks_painting_options

--- a/src/copick_utils/cli/picks2sphere.py
+++ b/src/copick_utils/cli/picks2sphere.py
@@ -1,7 +1,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 
@@ -20,13 +20,8 @@ from copick_utils.util.config_models import create_simple_config
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input picks.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_input_option("picks")
 @optgroup.group("\nTool Options", help="Options related to this tool.")
 @optgroup.option(

--- a/src/copick_utils/cli/picks2surface.py
+++ b/src/copick_utils/cli/picks2surface.py
@@ -1,7 +1,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 
@@ -20,13 +20,8 @@ from copick_utils.util.config_models import create_simple_config
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input picks.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_input_option("picks")
 @optgroup.group("\nTool Options", help="Options related to this tool.")
 @optgroup.option(

--- a/src/copick_utils/cli/picksin.py
+++ b/src/copick_utils/cli/picksin.py
@@ -1,7 +1,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 
@@ -21,13 +21,8 @@ from copick_utils.util.config_models import create_reference_config
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input picks.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_input_option("picks")
 @optgroup.group("\nReference Options", help="Options for reference volume (provide either mesh or segmentation).")
 @add_reference_mesh_option(required=False)

--- a/src/copick_utils/cli/picksout.py
+++ b/src/copick_utils/cli/picksout.py
@@ -3,7 +3,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 
@@ -23,13 +23,8 @@ from copick_utils.util.config_models import create_reference_config
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input picks.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_input_option("picks")
 @optgroup.group("\nReference Options", help="Options for reference volume (provide either mesh or segmentation).")
 @add_reference_mesh_option(required=False)

--- a/src/copick_utils/cli/rescale.py
+++ b/src/copick_utils/cli/rescale.py
@@ -3,7 +3,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 
@@ -17,13 +17,8 @@ from copick_utils.util.config_models import create_simple_config
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input segmentation.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_input_option("segmentation")
 @optgroup.group("\nTool Options", help="Options related to rescaling.")
 @optgroup.option(

--- a/src/copick_utils/cli/seg2mesh.py
+++ b/src/copick_utils/cli/seg2mesh.py
@@ -1,7 +1,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 
@@ -20,13 +20,8 @@ from copick_utils.util.config_models import create_simple_config
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input segmentations.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_input_option("segmentation")
 @optgroup.group("\nTool Options", help="Options related to this tool.")
 @add_marching_cubes_options

--- a/src/copick_utils/cli/seg2picks.py
+++ b/src/copick_utils/cli/seg2picks.py
@@ -1,7 +1,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 
@@ -20,13 +20,8 @@ from copick_utils.util.config_models import create_simple_config
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input segmentations.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_input_option("segmentation")
 @optgroup.group("\nTool Options", help="Options related to this tool.")
 @add_segmentation_processing_options

--- a/src/copick_utils/cli/seg_stats.py
+++ b/src/copick_utils/cli/seg_stats.py
@@ -3,7 +3,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 
 from copick_utils.cli.util import add_input_option, add_workers_option
@@ -15,13 +15,8 @@ from copick_utils.cli.util import add_input_option, add_workers_option
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input segmentation.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_input_option("segmentation")
 @optgroup.group("\nTool Options", help="Options related to this tool.")
 @optgroup.option(

--- a/src/copick_utils/cli/segop.py
+++ b/src/copick_utils/cli/segop.py
@@ -3,7 +3,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 
@@ -25,13 +25,8 @@ from copick_utils.util.config_models import (
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to input segmentations.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_multi_input_options("segmentation")
 @optgroup.group("\nTool Options", help="Options related to this tool.")
 @add_boolean_operation_option

--- a/src/copick_utils/cli/separate_components.py
+++ b/src/copick_utils/cli/separate_components.py
@@ -1,7 +1,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 
@@ -15,12 +15,8 @@ from copick_utils.util.config_models import create_simple_config
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input segmentation.")
-@optgroup.option(
-    "--run-names",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_input_option("segmentation")
 @optgroup.group("\nTool Options", help="Options related to this tool.")
 @optgroup.option(

--- a/src/copick_utils/cli/skeletonize.py
+++ b/src/copick_utils/cli/skeletonize.py
@@ -1,7 +1,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 
@@ -15,13 +15,8 @@ from copick_utils.util.config_models import create_simple_config
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input segmentation.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_input_option("segmentation")
 @optgroup.group("\nTool Options", help="Options related to this tool.")
 @optgroup.option(

--- a/src/copick_utils/cli/split_labels.py
+++ b/src/copick_utils/cli/split_labels.py
@@ -3,7 +3,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 
@@ -16,13 +16,8 @@ from copick_utils.cli.util import add_input_option, add_workers_option
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input segmentation.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_input_option("segmentation")
 @optgroup.group("\nTool Options", help="Options related to this tool.")
 @optgroup.option(

--- a/src/copick_utils/cli/thickness_filter.py
+++ b/src/copick_utils/cli/thickness_filter.py
@@ -3,7 +3,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import parse_copick_uri
 
@@ -17,13 +17,8 @@ from copick_utils.util.config_models import create_simple_config
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input segmentation.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_input_option("segmentation")
 @optgroup.group("\nTool Options", help="Options related to this tool.")
 @optgroup.option(

--- a/src/copick_utils/cli/validbox.py
+++ b/src/copick_utils/cli/validbox.py
@@ -3,7 +3,7 @@
 import click
 import copick
 from click_option_group import optgroup
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import add_config_option, add_debug_option, add_run_names_option
 from copick.util.log import get_logger
 from copick.util.uri import expand_output_uri, parse_copick_uri
 
@@ -16,13 +16,8 @@ from copick_utils.cli.util import add_output_option, add_tomogram_option
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @optgroup.group("\nInput Options", help="Options related to the input runs.")
-@optgroup.option(
-    "--run-names",
-    "-r",
-    multiple=True,
-    help="Specific run names to process (default: all runs).",
-)
 @add_tomogram_option(required=True)
 @optgroup.group("\nTool Options", help="Options related to this tool.")
 @optgroup.option(

--- a/tests/test_run_names_option.py
+++ b/tests/test_run_names_option.py
@@ -1,0 +1,37 @@
+"""Tests that copick-utils CLI commands use the shared run-selection option.
+
+All commands were de-duplicated onto ``add_run_names_option`` from
+``copick.cli.util``; ``separate_components`` and ``fit_spline`` additionally
+gained the ``-r`` short flag they previously lacked.
+"""
+
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+# A representative slice across the conversion / processing / logical groups,
+# including the two commands that previously lacked the -r short flag.
+COMMANDS = [
+    ("copick_utils.cli.separate_components", "separate_components"),
+    ("copick_utils.cli.fit_spline", "fit_spline"),
+    ("copick_utils.cli.picks2seg", "picks2seg"),
+    ("copick_utils.cli.seg2picks", "seg2picks"),
+    ("copick_utils.cli.segop", "segop"),
+    ("copick_utils.cli.rescale", "rescale"),
+    ("copick_utils.cli.combine_labels", "combine"),
+]
+
+
+@pytest.mark.parametrize(("dotted", "attr"), COMMANDS)
+def test_command_exposes_standard_run_option(runner, dotted, attr):
+    import importlib
+
+    cmd = getattr(importlib.import_module(dotted), attr)
+    out = runner.invoke(cmd, ["--help"]).output
+    assert "--run-names" in out
+    assert "-r" in out


### PR DESCRIPTION
Normalizes the run selection option across most of the copick CLIs to `-r/--run-names`